### PR TITLE
Open recent translations file on notification click

### DIFF
--- a/WhisperShortcut/HistoryLogger.swift
+++ b/WhisperShortcut/HistoryLogger.swift
@@ -1,0 +1,143 @@
+//
+//  HistoryLogger.swift
+//  WhisperShortcut
+//
+//  Stores a rolling history of recent prompts/transcriptions and can export
+//  the last N entries to a temp file for quick viewing in an editor.
+//
+
+import Foundation
+import AppKit
+
+final class HistoryLogger {
+  static let shared = HistoryLogger()
+
+  private enum Constants {
+    static let appSupportSubdirectory = "WhisperShortcut"
+    static let historyFilename = "history.json"
+    static let maxStoredEntries = 200
+    static let exportFilename = "WhisperShortcut-Recent.txt"
+    static let dateFormat = "yyyy-MM-dd HH:mm:ss"
+  }
+
+  enum EventType: String, Codable {
+    case prompt
+    case transcription
+    case voiceResponse
+    case readingText
+  }
+
+  struct Entry: Codable {
+    let timestamp: Date
+    let type: EventType
+    let text: String
+  }
+
+  private let ioQueue = DispatchQueue(
+    label: "com.magnusgoedde.whispershortcut.history",
+    qos: .background
+  )
+
+  private var entries: [Entry] = []
+
+  private init() {
+    loadFromDisk()
+  }
+
+  // MARK: - Public API
+  func log(type: EventType, text: String) {
+    let cleanText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    let entry = Entry(timestamp: Date(), type: type, text: cleanText)
+    ioQueue.async { [weak self] in
+      guard let self = self else { return }
+      self.entries.append(entry)
+      if self.entries.count > Constants.maxStoredEntries {
+        self.entries.removeFirst(self.entries.count - Constants.maxStoredEntries)
+      }
+      self.saveToDisk()
+      NSLog("🧠 HistoryLogger: Logged entry type=\(type.rawValue) (total=\(self.entries.count))")
+    }
+  }
+
+  func exportRecentToTempFile(limit: Int = 20) -> URL? {
+    var snapshot: [Entry] = []
+    ioQueue.sync { snapshot = Array(entries.suffix(limit)) }
+
+    let formatter = DateFormatter()
+    formatter.dateFormat = Constants.dateFormat
+
+    var lines: [String] = []
+    lines.append("WhisperShortcut – Recent History (last \(snapshot.count))")
+    lines.append("Generated: \(formatter.string(from: Date()))")
+    lines.append(String(repeating: "-", count: 64))
+    for (index, entry) in snapshot.enumerated() {
+      let dateStr = formatter.string(from: entry.timestamp)
+      lines.append("#\(index + 1) [\(entry.type.rawValue)] @ \(dateStr)")
+      lines.append(entry.text)
+      lines.append("")
+    }
+    let content = lines.joined(separator: "\n")
+
+    let tempDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+    let fileURL = tempDir.appendingPathComponent(Constants.exportFilename)
+
+    do {
+      try content.write(to: fileURL, atomically: true, encoding: .utf8)
+      NSLog("🧠 HistoryLogger: Exported recent history to \(fileURL.path)")
+      return fileURL
+    } catch {
+      NSLog("🧠 HistoryLogger: Failed to export recent history – \(error.localizedDescription)")
+      return nil
+    }
+  }
+
+  // MARK: - Persistence
+  private func appSupportDirectory() -> URL? {
+    guard let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+      return nil
+    }
+    let dir = base.appendingPathComponent(Constants.appSupportSubdirectory, isDirectory: true)
+    do {
+      try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+      return dir
+    } catch {
+      NSLog("🧠 HistoryLogger: Failed to create app support directory – \(error.localizedDescription)")
+      return nil
+    }
+  }
+
+  private func historyFileURL() -> URL? {
+    guard let dir = appSupportDirectory() else { return nil }
+    return dir.appendingPathComponent(Constants.historyFilename)
+  }
+
+  private func saveToDisk() {
+    guard let url = historyFileURL() else { return }
+    do {
+      let data = try JSONEncoder().encode(entries)
+      try data.write(to: url, options: .atomic)
+    } catch {
+      NSLog("🧠 HistoryLogger: Failed to save – \(error.localizedDescription)")
+    }
+  }
+
+  private func loadFromDisk() {
+    guard let url = historyFileURL(), FileManager.default.fileExists(atPath: url.path) else {
+      entries = []
+      return
+    }
+    do {
+      let data = try Data(contentsOf: url)
+      let decoded = try JSONDecoder().decode([Entry].self, from: data)
+      entries = decoded
+      if entries.count > Constants.maxStoredEntries {
+        entries = Array(entries.suffix(Constants.maxStoredEntries))
+      }
+      NSLog("🧠 HistoryLogger: Loaded \(entries.count) entries from disk")
+    } catch {
+      entries = []
+      NSLog("🧠 HistoryLogger: Failed to load – \(error.localizedDescription)")
+    }
+  }
+}
+

--- a/WhisperShortcut/PopupNotificationWindow.swift
+++ b/WhisperShortcut/PopupNotificationWindow.swift
@@ -87,6 +87,8 @@ class PopupNotificationWindow: NSWindow {
     // Make error notifications clickable for WhatsApp feedback
     if isError {
       setupErrorClickHandler()
+    } else {
+      setupSuccessClickHandler()
     }
 
     // Start auto-hide timer with appropriate duration
@@ -256,11 +258,28 @@ class PopupNotificationWindow: NSWindow {
     customContentView.wantsLayer = true
   }
 
+  private func setupSuccessClickHandler() {
+    if let clickableView = customContentView as? ClickableContentView {
+      clickableView.onClickHandler = { [weak self] in
+        self?.successWindowClicked()
+      }
+    }
+
+    customContentView.wantsLayer = true
+  }
+
   @objc private func errorWindowClicked() {
     // First open WhatsApp, then close notification
     openWhatsAppFeedback()
 
     // Delay closing the notification slightly to ensure WhatsApp opens
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+      self.hide()
+    }
+  }
+
+  @objc private func successWindowClicked() {
+    openRecentHistory()
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
       self.hide()
     }
@@ -292,6 +311,31 @@ class PopupNotificationWindow: NSWindow {
 
     // Open WhatsApp Web in default browser
     NSWorkspace.shared.open(whatsappURL)
+  }
+
+  private func openRecentHistory(limit: Int = 20) {
+    guard let fileURL = HistoryLogger.shared.exportRecentToTempFile(limit: limit) else {
+      return
+    }
+
+    // Prefer Cursor if installed, otherwise fall back to default handler
+    let cursorAppPath = "/Applications/Cursor.app"
+    if FileManager.default.fileExists(atPath: cursorAppPath) {
+      let appURL = URL(fileURLWithPath: cursorAppPath, isDirectory: true)
+      let config = NSWorkspace.OpenConfiguration()
+      NSWorkspace.shared.open([fileURL], withApplicationAt: appURL, configuration: config) {
+        app, error in
+        if let error = error {
+          NSLog("🪟 Popup: Failed to open with Cursor – \(error.localizedDescription). Falling back to default.")
+          NSWorkspace.shared.open(fileURL)
+        } else {
+          NSLog("🪟 Popup: Opened recent history in Cursor at \(fileURL.path)")
+        }
+      }
+    } else {
+      NSWorkspace.shared.open(fileURL)
+      NSLog("🪟 Popup: Opened recent history in default editor at \(fileURL.path)")
+    }
   }
 
   private func setupScrollView() {
@@ -594,18 +638,22 @@ extension PopupNotificationWindow {
   }
 
   static func showPromptResponse(_ response: String) {
+    HistoryLogger.shared.log(type: .prompt, text: response)
     showSuccessNotification(text: response)
   }
 
   static func showTranscriptionResponse(_ transcription: String) {
+    HistoryLogger.shared.log(type: .transcription, text: transcription)
     showSuccessNotification(text: transcription)
   }
 
   static func showVoiceResponse(_ response: String) {
+    HistoryLogger.shared.log(type: .voiceResponse, text: response)
     showSuccessNotification(text: response)
   }
 
   static func showReadingText(_ text: String) {
+    HistoryLogger.shared.log(type: .readingText, text: text)
     showSuccessNotification(title: "🔊 Reading Text", text: text)
   }
 


### PR DESCRIPTION
Implement clickable success notifications to open a temp file containing the last 20 recent prompts and transcriptions.

---
<a href="https://cursor.com/background-agent?bcId=bc-6666036a-2ac8-4952-8ed8-7f59c912f765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6666036a-2ac8-4952-8ed8-7f59c912f765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

