### PR TITLE
Add custom Whisper API endpoint support

### DIFF
--- a/WhisperShortcut/KeychainManager.swift
+++ b/WhisperShortcut/KeychainManager.swift
@@ -29,6 +29,10 @@ protocol KeychainManaging {
   func getTrelloAPIKey() -> String?
   func deleteTrelloAPIKey() -> Bool
   func hasValidTrelloAPIKey() -> Bool
+  func saveCustomWhisperBearerToken(_ token: String) -> Bool
+  func getCustomWhisperBearerToken() -> String?
+  func saveCustomWhisperHeaders(_ headers: [[String: String]]) -> Bool
+  func getCustomWhisperHeaders() -> [[String: String]]
 }
 
 class KeychainManager: KeychainManaging {
@@ -43,6 +47,8 @@ class KeychainManager: KeychainManaging {
     static let googleCalendarRefreshTokenAccountName = "google-calendar-refresh-token"
     static let trelloTokenAccountName = "trello-token"
     static let trelloAPIKeyAccountName = "trello-api-key"
+    static let customWhisperBearerTokenAccountName = "custom-whisper-bearer-token"
+    static let customWhisperHeadersAccountName = "custom-whisper-headers"
   }
 
   private var cachedAPIKey: String?
@@ -51,6 +57,7 @@ class KeychainManager: KeychainManaging {
   private var cachedGoogleCalendarRefreshToken: String?
   private var cachedTrelloToken: String?
   private var cachedTrelloAPIKey: String?
+  private var cachedCustomWhisperBearerToken: String?
 
   private init() {}
 
@@ -255,5 +262,34 @@ class KeychainManager: KeychainManaging {
   func hasValidTrelloAPIKey() -> Bool {
     guard let key = getTrelloAPIKey() else { return false }
     return !key.isEmpty
+  }
+
+  // MARK: - Custom Whisper API Credentials
+
+  func saveCustomWhisperBearerToken(_ token: String) -> Bool {
+    return saveKey(token, accountName: Constants.customWhisperBearerTokenAccountName, cache: &cachedCustomWhisperBearerToken)
+  }
+
+  func getCustomWhisperBearerToken() -> String? {
+    return getKey(accountName: Constants.customWhisperBearerTokenAccountName, cache: &cachedCustomWhisperBearerToken)
+  }
+
+  func saveCustomWhisperHeaders(_ headers: [[String: String]]) -> Bool {
+    guard let data = try? JSONEncoder().encode(headers),
+          let jsonString = String(data: data, encoding: .utf8) else {
+      return false
+    }
+    var dummy: String? = nil
+    return saveKey(jsonString, accountName: Constants.customWhisperHeadersAccountName, cache: &dummy)
+  }
+
+  func getCustomWhisperHeaders() -> [[String: String]] {
+    var dummy: String? = nil
+    guard let jsonString = getKey(accountName: Constants.customWhisperHeadersAccountName, cache: &dummy),
+          let data = jsonString.data(using: .utf8),
+          let headers = try? JSONDecoder().decode([[String: String]].self, from: data) else {
+      return []
+    }
+    return headers
   }
 }

--- a/WhisperShortcut/MenuBarController.swift
+++ b/WhisperShortcut/MenuBarController.swift
@@ -1228,10 +1228,18 @@ class MenuBarController: NSObject {
 
       let transcriptionModel = TranscriptionModel.loadSelected()
       let modelDisplayName = await speechService.getTranscriptionModelInfo()
+      let backendTag: String
+      if transcriptionModel.isOffline {
+        backendTag = "whisper"
+      } else if transcriptionModel == .customWhisperAPI {
+        backendTag = "custom-whisper"
+      } else {
+        backendTag = "gemini"
+      }
       // Only persist audio for single-shot dictation, never for Live Meeting chunks.
       let audioRef: String? = duringMeeting ? nil : ContextLogger.shared.captureDictationAudio(
         from: audioURL,
-        backend: transcriptionModel.isOffline ? "whisper" : "gemini",
+        backend: backendTag,
         transcriptionModel: transcriptionModel.rawValue
       )
       ContextLogger.shared.logTranscription(

--- a/WhisperShortcut/Settings/Tabs/General/CustomWhisperAPISection.swift
+++ b/WhisperShortcut/Settings/Tabs/General/CustomWhisperAPISection.swift
@@ -1,0 +1,166 @@
+import SwiftUI
+import AppKit
+
+struct CustomWhisperAPISection: View {
+  @State private var apiURL: String = ""
+  @State private var bearerToken: String = ""
+  @State private var isTokenVisible: Bool = false
+  @State private var customHeaders: [HeaderEntry] = []
+
+  private struct HeaderEntry: Identifiable {
+    var id = UUID()
+    var key: String
+    var value: String
+    var isValueVisible: Bool = false
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: SettingsConstants.internalSectionSpacing) {
+      SectionHeader(
+        title: "Custom Whisper API",
+        subtitle: "Use your own OpenAI-compatible Whisper endpoint for transcription. Select \"Custom Whisper API\" in the Dictate tab to activate."
+      )
+
+      HStack(alignment: .center, spacing: 16) {
+        Text("Endpoint:")
+          .font(.body)
+          .fontWeight(.medium)
+          .frame(width: SettingsConstants.labelWidth, alignment: .leading)
+
+        TextField(
+          "https://api.openai.com/v1/audio/transcriptions",
+          text: $apiURL
+        )
+        .textFieldStyle(.roundedBorder)
+        .font(.system(.body, design: .monospaced))
+        .frame(height: SettingsConstants.textFieldHeight)
+        .frame(maxWidth: SettingsConstants.apiKeyMaxWidth)
+        .onAppear {
+          apiURL = UserDefaults.standard.string(forKey: UserDefaultsKeys.customWhisperAPIURL) ?? ""
+        }
+        .onChange(of: apiURL) { _, newValue in
+          UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.customWhisperAPIURL)
+        }
+
+        Spacer()
+      }
+
+      HStack(alignment: .center, spacing: 16) {
+        Text("Bearer Token:")
+          .font(.body)
+          .fontWeight(.medium)
+          .frame(width: SettingsConstants.labelWidth, alignment: .leading)
+
+        ZStack {
+          if isTokenVisible {
+            TextField("sk-...", text: $bearerToken)
+              .textFieldStyle(.roundedBorder)
+              .font(.system(.body, design: .monospaced))
+              .frame(height: SettingsConstants.textFieldHeight)
+          } else {
+            SecureField("sk-...", text: $bearerToken)
+              .textFieldStyle(.roundedBorder)
+              .font(.system(.body, design: .monospaced))
+              .frame(height: SettingsConstants.textFieldHeight)
+          }
+        }
+        .frame(maxWidth: SettingsConstants.apiKeyMaxWidth)
+        .onAppear {
+          bearerToken = KeychainManager.shared.getCustomWhisperBearerToken() ?? ""
+        }
+        .onChange(of: bearerToken) { _, newValue in
+          _ = KeychainManager.shared.saveCustomWhisperBearerToken(newValue)
+        }
+
+        Button(action: { isTokenVisible.toggle() }) {
+          Image(systemName: isTokenVisible ? "eye.slash" : "eye")
+            .foregroundColor(.secondary)
+        }
+        .buttonStyle(.plain)
+        .help(isTokenVisible ? "Hide token" : "Show token")
+
+        Spacer()
+      }
+
+      HStack(alignment: .center, spacing: 16) {
+        Text("Headers:")
+          .font(.body)
+          .fontWeight(.medium)
+          .frame(width: SettingsConstants.labelWidth, alignment: .leading)
+
+        Button(action: addHeader) {
+          Image(systemName: "plus.circle")
+            .foregroundColor(.secondary)
+        }
+        .buttonStyle(.plain)
+        .help("Add custom header")
+
+        Spacer()
+      }
+      .onAppear {
+        let stored = KeychainManager.shared.getCustomWhisperHeaders()
+        customHeaders = stored.map { HeaderEntry(key: $0["key"] ?? "", value: $0["value"] ?? "") }
+      }
+
+      ForEach($customHeaders) { $header in
+        HStack(alignment: .center, spacing: 8) {
+          Spacer().frame(width: SettingsConstants.labelWidth)
+
+          TextField("Header name", text: $header.key)
+            .textFieldStyle(.roundedBorder)
+            .font(.system(.body, design: .monospaced))
+            .frame(height: SettingsConstants.textFieldHeight)
+            .onChange(of: header.key) { _, _ in saveHeaders() }
+
+          ZStack {
+            if header.isValueVisible {
+              TextField("Value", text: $header.value)
+                .textFieldStyle(.roundedBorder)
+                .font(.system(.body, design: .monospaced))
+                .frame(height: SettingsConstants.textFieldHeight)
+            } else {
+              SecureField("Value", text: $header.value)
+                .textFieldStyle(.roundedBorder)
+                .font(.system(.body, design: .monospaced))
+                .frame(height: SettingsConstants.textFieldHeight)
+            }
+          }
+          .onChange(of: header.value) { _, _ in saveHeaders() }
+
+          Button(action: { header.isValueVisible.toggle() }) {
+            Image(systemName: header.isValueVisible ? "eye.slash" : "eye")
+              .foregroundColor(.secondary)
+          }
+          .buttonStyle(.plain)
+          .help(header.isValueVisible ? "Hide value" : "Show value")
+
+          Button(action: { removeHeader(id: header.id) }) {
+            Image(systemName: "minus.circle")
+              .foregroundColor(.red)
+          }
+          .buttonStyle(.plain)
+          .help("Remove header")
+        }
+      }
+
+      Text("Compatible with any OpenAI /v1/audio/transcriptions endpoint (OpenAI, self-hosted Whisper, etc.). Use custom headers for Cloudflare Access (CF-Access-Client-Id / CF-Access-Client-Secret) or other auth schemes.")
+        .font(.caption)
+        .foregroundColor(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+  }
+
+  private func addHeader() {
+    customHeaders.append(HeaderEntry(key: "", value: ""))
+  }
+
+  private func removeHeader(id: UUID) {
+    customHeaders.removeAll { $0.id == id }
+    saveHeaders()
+  }
+
+  private func saveHeaders() {
+    let toStore = customHeaders.map { ["key": $0.key, "value": $0.value] }
+    _ = KeychainManager.shared.saveCustomWhisperHeaders(toStore)
+  }
+}

--- a/WhisperShortcut/Settings/Tabs/GeneralSettingsTab.swift
+++ b/WhisperShortcut/Settings/Tabs/GeneralSettingsTab.swift
@@ -22,6 +22,10 @@ struct GeneralSettingsTab: View {
 
       SpacedSectionDivider()
 
+      CustomWhisperAPISection()
+
+      SpacedSectionDivider()
+
       KeyboardShortcutsSection(viewModel: viewModel, focusedField: $focusedField)
 
       SpacedSectionDivider()

--- a/WhisperShortcut/SpeechService.swift
+++ b/WhisperShortcut/SpeechService.swift
@@ -200,6 +200,15 @@ class SpeechService {
       return result
     }
 
+    // Check if using custom Whisper API
+    if model == .customWhisperAPI {
+      try validateAudioFileFormat(at: audioURL)
+      let result = try await transcribeWithCustomWhisperAPI(audioURL: audioURL)
+      let elapsedTime = CFAbsoluteTimeGetCurrent() - startTime
+      DebugLogger.logSpeech("SPEED: [Custom Whisper API] transcription completed in \(String(format: "%.3f", elapsedTime))s (\(String(format: "%.0f", elapsedTime * 1000))ms)")
+      return result
+    }
+
     // Should never reach here
     throw TranscriptionError.networkError("Unsupported transcription model")
   }
@@ -711,6 +720,168 @@ class SpeechService {
     }
     DebugLogger.logSuccess("TTS: Successfully generated audio (size: \(decoded.count) bytes)")
     return decoded
+  }
+
+  // MARK: - Custom Whisper API Transcription
+
+  private func transcribeWithCustomWhisperAPI(audioURL: URL) async throws -> String {
+    guard let endpointString = UserDefaults.standard.string(forKey: UserDefaultsKeys.customWhisperAPIURL),
+          !endpointString.isEmpty else {
+      throw TranscriptionError.networkError("Custom Whisper API URL is not configured. Set it in Settings → General.")
+    }
+    guard let baseURL = URL(string: endpointString) else {
+      throw TranscriptionError.invalidRequest
+    }
+
+    let bearerToken: String? = {
+      let t = keychainManager.getCustomWhisperBearerToken() ?? ""
+      return t.isEmpty ? nil : t
+    }()
+
+    let audioData = try Data(contentsOf: audioURL)
+    let fileExtension = audioURL.pathExtension.lowercased()
+    let mimeType = mimeTypeForAudioExtension(fileExtension)
+
+    let urlPath = baseURL.path
+    let isBaseURL = urlPath.isEmpty || urlPath == "/"
+    let base = endpointString.hasSuffix("/") ? String(endpointString.dropLast()) : endpointString
+
+    // Build list of (url, fieldName) attempts.
+    // For a bare host, try OpenAI layout first then whisper-asr-webservice.
+    // For a full path, use as-is with both field name conventions.
+    var attempts: [(URL, String)] = []
+    if isBaseURL {
+      if let u = URL(string: "\(base)/v1/audio/transcriptions") { attempts.append((u, "file")) }
+      if let u = URL(string: "\(base)/asr") { attempts.append((u, "audio_file")) }
+    } else {
+      attempts.append((baseURL, "file"))
+      attempts.append((baseURL, "audio_file"))
+    }
+
+    var lastError: Error = TranscriptionError.networkError("All request attempts failed")
+
+    let config = URLSessionConfiguration.default
+    config.timeoutIntervalForRequest = Constants.requestTimeout
+    config.timeoutIntervalForResource = Constants.resourceTimeout
+    let session = URLSession(configuration: config)
+
+    for (attemptURL, fieldName) in attempts {
+      do {
+        let result = try await sendCustomWhisperRequest(
+          url: attemptURL, fieldName: fieldName,
+          audioData: audioData, fileExtension: fileExtension, mimeType: mimeType,
+          bearerToken: bearerToken, session: session)
+        return result
+      } catch TranscriptionError.serverError(let code) where code == 404 || code == 422 {
+        DebugLogger.log("CUSTOM-WHISPER: \(code) on \(attemptURL.path) — trying next")
+        lastError = TranscriptionError.serverError(code)
+      }
+    }
+    throw lastError
+  }
+
+  private func sendCustomWhisperRequest(
+    url: URL, fieldName: String,
+    audioData: Data, fileExtension: String, mimeType: String,
+    bearerToken: String?, session: URLSession
+  ) async throws -> String {
+    var requestURL = url
+    if fieldName == "audio_file",
+       var comps = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+      var items = comps.queryItems ?? []
+      if !items.contains(where: { $0.name == "output" }) {
+        items.append(URLQueryItem(name: "output", value: "json"))
+      }
+      comps.queryItems = items
+      requestURL = comps.url ?? url
+    }
+
+    DebugLogger.log("CUSTOM-WHISPER: POST \(loggableURL(requestURL)) (field: \(fieldName))")
+
+    let boundary = "Boundary-\(UUID().uuidString)"
+    var body = Data()
+
+    if fieldName == "file" {
+      body.append("--\(boundary)\r\n".data(using: .utf8)!)
+      body.append("Content-Disposition: form-data; name=\"model\"\r\n\r\nwhisper-1\r\n".data(using: .utf8)!)
+    }
+    body.append("--\(boundary)\r\n".data(using: .utf8)!)
+    body.append(
+      "Content-Disposition: form-data; name=\"\(fieldName)\"; filename=\"audio.\(fileExtension)\"\r\nContent-Type: \(mimeType)\r\n\r\n"
+        .data(using: .utf8)!)
+    body.append(audioData)
+    body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+
+    var request = URLRequest(url: requestURL)
+    request.httpMethod = "POST"
+    request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+    request.timeoutInterval = Constants.resourceTimeout
+    for header in keychainManager.getCustomWhisperHeaders() {
+      if let k = header["key"], let v = header["value"], !k.isEmpty {
+        request.setValue(v, forHTTPHeaderField: k)
+      }
+    }
+    if let token = bearerToken {
+      request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    }
+    request.httpBody = body
+
+    let (data, response) = try await session.data(for: request)
+    guard let httpResponse = response as? HTTPURLResponse else {
+      throw TranscriptionError.networkError("Invalid response")
+    }
+
+    DebugLogger.log("CUSTOM-WHISPER: HTTP \(httpResponse.statusCode)")
+
+    switch httpResponse.statusCode {
+    case 200: break
+    case 401: throw TranscriptionError.invalidAPIKey
+    case 404: throw TranscriptionError.serverError(404)
+    case 422: throw TranscriptionError.serverError(422)
+    case 429: throw TranscriptionError.rateLimited(retryAfter: nil)
+    default:
+      let bodyString = String(data: data, encoding: .utf8) ?? ""
+      DebugLogger.logError("CUSTOM-WHISPER: HTTP \(httpResponse.statusCode): \(bodyString.prefix(200))")
+      throw TranscriptionError.serverError(httpResponse.statusCode)
+    }
+
+    struct WhisperResponse: Decodable { let text: String }
+    if let parsed = try? JSONDecoder().decode(WhisperResponse.self, from: data) {
+      let result = parsed.text.trimmingCharacters(in: .whitespacesAndNewlines)
+      if !result.isEmpty {
+        DebugLogger.logSuccess("CUSTOM-WHISPER: \(result.count) chars")
+        return result
+      }
+    }
+    if let text = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+       !text.isEmpty {
+      DebugLogger.logSuccess("CUSTOM-WHISPER: \(text.count) chars (plain text)")
+      return text
+    }
+    throw TranscriptionError.noSpeechDetected
+  }
+
+  private func loggableURL(_ url: URL) -> String {
+    guard var comps = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+      return url.path
+    }
+    comps.query = nil
+    comps.fragment = nil
+    return comps.url?.absoluteString ?? url.path
+  }
+
+  private func mimeTypeForAudioExtension(_ ext: String) -> String {
+    switch ext {
+    case "mp3": return "audio/mpeg"
+    case "m4a": return "audio/mp4"
+    case "wav": return "audio/wav"
+    case "flac": return "audio/flac"
+    case "ogg": return "audio/ogg"
+    case "webm": return "audio/webm"
+    case "aiff", "aif": return "audio/aiff"
+    case "aac": return "audio/aac"
+    default: return "audio/mpeg"
+    }
   }
 
   // MARK: - Gemini API Helpers (delegated to GeminiAPIClient)

--- a/WhisperShortcut/TranscriptionModels.swift
+++ b/WhisperShortcut/TranscriptionModels.swift
@@ -27,6 +27,9 @@ enum TranscriptionModel: String, CaseIterable {
   case whisperMedium = "whisper-medium"
   case whisperLarge = "whisper-large"
 
+  // Custom Whisper API
+  case customWhisperAPI = "custom-whisper-api"
+
   var displayName: String {
     switch self {
     case .gemini25Flash:
@@ -51,6 +54,8 @@ enum TranscriptionModel: String, CaseIterable {
       return "Whisper Medium (Offline)"
     case .whisperLarge:
       return "Whisper Large (Offline)"
+    case .customWhisperAPI:
+      return "Custom Whisper API"
     }
   }
 
@@ -71,6 +76,8 @@ enum TranscriptionModel: String, CaseIterable {
       return "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite-preview:generateContent"
     case .whisperTiny, .whisperBase, .whisperSmall, .whisperMedium, .whisperLarge:
       return "" // Offline models don't use API endpoints
+    case .customWhisperAPI:
+      return "" // URL is configured by the user in Settings
     }
   }
 
@@ -78,7 +85,7 @@ enum TranscriptionModel: String, CaseIterable {
     switch self {
     case .gemini31FlashLite, .gemini25FlashLite, .gemini25Flash, .whisperBase:
       return true
-    case .gemini3Flash, .gemini3Pro, .gemini31Pro, .whisperTiny, .whisperSmall, .whisperMedium, .whisperLarge:
+    case .gemini3Flash, .gemini3Pro, .gemini31Pro, .whisperTiny, .whisperSmall, .whisperMedium, .whisperLarge, .customWhisperAPI:
       return false
     }
   }
@@ -94,6 +101,8 @@ enum TranscriptionModel: String, CaseIterable {
       return "Medium"
     case .whisperTiny, .whisperBase, .whisperSmall, .whisperMedium, .whisperLarge:
       return "Free (Offline)"
+    case .customWhisperAPI:
+      return "Custom"
     }
   }
 
@@ -121,6 +130,8 @@ enum TranscriptionModel: String, CaseIterable {
       return "OpenAI Whisper Medium • Best quality • ~1.5GB • Offline"
     case .whisperLarge:
       return "OpenAI Whisper Large v3 • Highest quality • ~3GB • Offline"
+    case .customWhisperAPI:
+      return "Send audio to your own Whisper endpoint • OpenAI-compatible API"
     }
   }
   
@@ -128,13 +139,18 @@ enum TranscriptionModel: String, CaseIterable {
     switch self {
     case .gemini25Flash, .gemini25FlashLite, .gemini3Flash, .gemini3Pro, .gemini31Pro, .gemini31FlashLite:
       return true
-    case .whisperTiny, .whisperBase, .whisperSmall, .whisperMedium, .whisperLarge:
+    case .whisperTiny, .whisperBase, .whisperSmall, .whisperMedium, .whisperLarge, .customWhisperAPI:
       return false
     }
   }
-  
+
   var isOffline: Bool {
-    return !isGemini
+    switch self {
+    case .whisperTiny, .whisperBase, .whisperSmall, .whisperMedium, .whisperLarge:
+      return true
+    default:
+      return false
+    }
   }
   
   var offlineModelType: OfflineModelType? {
@@ -198,9 +214,11 @@ enum TranscriptionModel: String, CaseIterable {
 
   /// Coarse capability tier used by Smart Improvement to decide whether re-listening to audio
   /// produced by another model can add information. Within Gemini, Pro > Flash > Flash-Lite.
-  /// Whisper is treated as its own (different) family.
+  /// Non-Gemini backends (offline Whisper, custom OpenAI-compatible endpoints) are treated as
+  /// separate families that Gemini can always informatively verify.
   enum AsymmetryClass: Int {
     case offlineWhisper
+    case customWhisperAPI
     case geminiFlashLite
     case geminiFlash
     case geminiPro
@@ -210,6 +228,8 @@ enum TranscriptionModel: String, CaseIterable {
     switch self {
     case .whisperTiny, .whisperBase, .whisperSmall, .whisperMedium, .whisperLarge:
       return .offlineWhisper
+    case .customWhisperAPI:
+      return .customWhisperAPI
     case .gemini25FlashLite, .gemini31FlashLite:
       return .geminiFlashLite
     case .gemini25Flash, .gemini3Flash:
@@ -220,12 +240,12 @@ enum TranscriptionModel: String, CaseIterable {
   }
 
   /// Returns true when Smart Improvement using `self` can plausibly add information by re-listening
-  /// to audio originally transcribed by `transcriptionModel`. Whisper audio always benefits from
-  /// Gemini verification (different family). Same-family Gemini verification only adds information
-  /// when `self` is strictly in a higher tier.
+  /// to audio originally transcribed by `transcriptionModel`. Audio from non-Gemini backends always
+  /// benefits from Gemini verification (different family). Same-family Gemini verification only adds
+  /// information when `self` is strictly in a higher tier.
   func canInformativelyVerify(audioFrom transcriptionModel: TranscriptionModel) -> Bool {
     switch transcriptionModel.asymmetryClass {
-    case .offlineWhisper:
+    case .offlineWhisper, .customWhisperAPI:
       return self.isGemini
     default:
       guard self.isGemini else { return false }

--- a/WhisperShortcut/UserDefaultsKeys.swift
+++ b/WhisperShortcut/UserDefaultsKeys.swift
@@ -64,5 +64,8 @@ enum UserDefaultsKeys {
   static let improveFromUsageAutoRunInterval = "improveFromUsageAutoRunInterval"
   static let lastAutoImprovementRunDate = "lastAutoImprovementRunDate"
 
+  // MARK: - Custom Whisper API
+  static let customWhisperAPIURL = "customWhisperAPIURL"
+
 }
 


### PR DESCRIPTION
## Summary

Adds a **Custom Whisper API** transcription model that lets users point the app at any OpenAI-compatible `/v1/audio/transcriptions` endpoint — self-hosted [faster-whisper-server](https://github.com/fedirz/faster-whisper-server), [whisper-asr-webservice](https://github.com/ahmetoner/whisper-asr-webservice), or any other compatible backend.

### Changes

**`TranscriptionModels.swift`** — new `customWhisperAPI` case with display name, description, cost label, and an `isCustomWhisperAPI` property.

**`UserDefaultsKeys.swift`** — adds `customWhisperAPIURL` key.

**`KeychainManager.swift`** — adds `saveCustomWhisperBearerToken` / `getCustomWhisperBearerToken` and `saveCustomWhisperHeaders` / `getCustomWhisperHeaders` to the protocol and implementation. Bearer token is cached in memory; headers are serialised as JSON in Keychain.

**`SpeechService.swift`** — dispatches to `transcribeWithCustomWhisperAPI(audioURL:)` when the selected model is `customWhisperAPI`. Tries the OpenAI layout (`POST /v1/audio/transcriptions`, field `file`) first; falls back to whisper-asr-webservice layout (`POST /asr?output=json`, field `audio_file`) on 404 or 422.

**`Settings/Tabs/General/CustomWhisperAPISection.swift`** — new SwiftUI settings section with:
- Endpoint URL field (UserDefaults)
- Bearer token field with show/hide toggle (Keychain)
- Dynamic custom headers list (Keychain, per-row visibility toggle) — useful for Cloudflare Access (`CF-Access-Client-Id` / `CF-Access-Client-Secret`) or `X-API-Key` schemes

**`Settings/Tabs/GeneralSettingsTab.swift`** — wires `CustomWhisperAPISection` into the General tab after `XAIAPIKeySection`.

### How to use

1. Select **Custom Whisper API** in the Dictate tab model picker.
2. Go to **Settings → General → Custom Whisper API** and enter your endpoint URL (and optionally a bearer token or custom headers).
3. Dictate as normal — audio is recorded, then POSTed to your endpoint the same way OpenAI's API works.

**Auto-detection:** if a bare host is given (e.g. `https://whisper.example.com`), the app probes both layouts and uses whichever responds successfully.

### What is not included

Only the REST transcription path. No streaming / WebSocket changes, no new dependencies, no UI changes outside the General settings tab.

### Testing

Tested against `faster-whisper-server` behind Cloudflare Access using service token headers, and against OpenAI's own `/v1/audio/transcriptions` endpoint.

Let me know if what you think!