### PR TITLE
implementer: fail a stalled GPT-Transcribe round-trip in 60s instead of hanging

### DIFF
--- a/WhisperShortcut/ContextLogger.swift
+++ b/WhisperShortcut/ContextLogger.swift
@@ -73,6 +73,10 @@ enum OutcomeSignal: String {
   /// separates "clipboard held no text" from "clipboard was unreachable" — a distinction the
   /// interaction log could not previously make, since neither wrote a record at all.
   case promptNoSelection
+  /// A cloud transcription round-trip hit the client deadline instead of returning.
+  /// Distinct from `cancelledWhileProcessing`: the app gave up, the user did not.
+  /// `detail.phase` / `timeoutSeconds` / `logPrefix` identify which path stalled.
+  case requestTimedOut
 }
 
 // MARK: - System Prompt History Entry

--- a/WhisperShortcut/NetworkDeadline.swift
+++ b/WhisperShortcut/NetworkDeadline.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Wall-clock deadline around a single `URLSession` round-trip.
+///
+/// `URLSession`'s own timers are not a reliable stall detector on this path:
+/// `timeoutIntervalForRequest` does not start until the first response byte, and
+/// `timeoutIntervalForResource` is not consistently enforced on reused HTTP/2
+/// connections (OpenAI's API). Measured GPT-Transcribe hangs sat in `transcribing`
+/// for 3.5–12.8 minutes until the user cancelled (improvement-ledger I2). A Task
+/// deadline cancels the request regardless of those timers.
+enum NetworkDeadline {
+
+  /// Cap for one OpenAI-compatible transcription POST. 60s is well under the I2
+  /// falsifier (`gapMs > 120000`) and far above typical GPT-Transcribe latency
+  /// (1–5s for a dictation). Matches Gemini's request-timeout copy so the user
+  /// sees the same "over 60 seconds" message on either provider.
+  static let transcriptionRequestTimeout: TimeInterval = 60
+
+  private enum Race {
+    case completed(Data, URLResponse)
+    case timedOut
+  }
+
+  /// Returns `session.data(for:)` or throws `TranscriptionError.requestTimeout`
+  /// if `timeout` elapses first. A URLSession-native `.timedOut` is mapped to
+  /// the same error; a user cancel stays a `CancellationError`.
+  static func data(
+    for request: URLRequest,
+    session: URLSession,
+    timeout: TimeInterval
+  ) async throws -> (Data, URLResponse) {
+    try await withThrowingTaskGroup(of: Race.self) { group in
+      group.addTask {
+        do {
+          let (data, response) = try await session.data(for: request)
+          return .completed(data, response)
+        } catch let error as URLError where error.code == .timedOut {
+          throw TranscriptionError.requestTimeout
+        } catch let error as URLError where error.code == .cancelled {
+          throw CancellationError()
+        }
+      }
+      group.addTask {
+        try await Task.sleep(nanoseconds: UInt64(max(0, timeout) * 1_000_000_000))
+        return .timedOut
+      }
+      defer { group.cancelAll() }
+      guard let first = try await group.next() else {
+        throw TranscriptionError.requestTimeout
+      }
+      switch first {
+      case .completed(let data, let response):
+        return (data, response)
+      case .timedOut:
+        throw TranscriptionError.requestTimeout
+      }
+    }
+  }
+}

--- a/WhisperShortcut/SpeechErrorFormatter.swift
+++ b/WhisperShortcut/SpeechErrorFormatter.swift
@@ -180,10 +180,10 @@ struct SpeechErrorFormatter {
       return """
         ⏰ Request Timeout
 
-        The server took too long to start responding (over 60 seconds).
+        The transcription service took too long to respond (over 60 seconds).
 
         This usually means:
-        • Google servers are overloaded
+        • The service is overloaded or stalled
         • Your internet connection is very slow
         • The API endpoint is temporarily unavailable
 
@@ -202,7 +202,7 @@ struct SpeechErrorFormatter {
         This usually means:
         • Very large audio file (close to 20MB limit)
         • Slow internet connection during upload/download
-        • Google processing is taking unusually long
+        • The provider is taking unusually long
 
         Solutions:
         • Try with a shorter recording

--- a/WhisperShortcut/SpeechService.swift
+++ b/WhisperShortcut/SpeechService.swift
@@ -1936,7 +1936,12 @@ class SpeechService {
     var request = URLRequest(url: requestURL)
     request.httpMethod = "POST"
     request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
-    request.timeoutInterval = Constants.resourceTimeout
+    // Idle timeout: 60s, not the 300s resourceTimeout this used to copy. Setting
+    // URLRequest.timeoutInterval to 300 overrode the session's 60s request timer
+    // and, combined with HTTP/2 keep-alive, let GPT-Transcribe sit in
+    // `transcribing` for minutes (I2). The Task deadline below is the real
+    // backstop — URLSession timers do not reliably fire on this path.
+    request.timeoutInterval = NetworkDeadline.transcriptionRequestTimeout
     for header in extraHeaders {
       if let k = header["key"], let v = header["value"], !k.isEmpty {
         request.setValue(v, forHTTPHeaderField: k)
@@ -1947,7 +1952,24 @@ class SpeechService {
     }
     request.httpBody = body
 
-    let (data, response) = try await session.data(for: request)
+    let (data, response): (Data, URLResponse)
+    do {
+      (data, response) = try await NetworkDeadline.data(
+        for: request,
+        session: session,
+        timeout: NetworkDeadline.transcriptionRequestTimeout)
+    } catch TranscriptionError.requestTimeout {
+      DebugLogger.logError(
+        "\(logPrefix): stalled round-trip aborted after \(Int(NetworkDeadline.transcriptionRequestTimeout))s (NetworkDeadline)")
+      ContextLogger.shared.logSignal(
+        .requestTimedOut, mode: "transcription",
+        detail: [
+          "phase": "transcribing",
+          "timeoutSeconds": "\(Int(NetworkDeadline.transcriptionRequestTimeout))",
+          "logPrefix": logPrefix
+        ])
+      throw TranscriptionError.requestTimeout
+    }
     guard let httpResponse = response as? HTTPURLResponse else {
       throw TranscriptionError.networkError("Invalid response")
     }
@@ -1992,8 +2014,9 @@ class SpeechService {
 
   /// Shared session used for OpenAI-compatible multipart transcription and the
   /// OpenAI Dictate Prompt path. Reuses the same connection pool as the chat
-  /// providers (`LLMHTTPSession.shared`), which is configured with identical
-  /// 60s/300s timeouts.
+  /// providers (`LLMHTTPSession.shared`). Transcription POSTs do not rely on
+  /// those 60s/300s timers — see `NetworkDeadline` — because they do not fire
+  /// reliably on reused HTTP/2 connections.
   private func makeTranscriptionURLSession() -> URLSession {
     LLMHTTPSession.shared
   }

--- a/WhisperShortcutTests/NetworkDeadlineTests.swift
+++ b/WhisperShortcutTests/NetworkDeadlineTests.swift
@@ -1,0 +1,145 @@
+import Testing
+import Foundation
+@testable import WhisperShortcut_AppStore
+
+/// Pins the stall detector that sits in front of OpenAI-compatible transcription.
+///
+/// I2's hangs (3.5–12.8 min in `transcribing`) happened because `URLSession`'s
+/// timers did not fire. These tests drive `NetworkDeadline` through a `URLProtocol`
+/// stub so they never touch the network, and they fail if the production cap
+/// drifts back above the 120s falsifier.
+@Suite("Network deadline")
+struct NetworkDeadlineTests {
+
+  // MARK: - Production cap
+
+  @Test("The transcription cap is 60s — under the 120s cancelledWhileProcessing falsifier")
+  func transcriptionTimeoutIsUnderFalsifier() {
+    #expect(NetworkDeadline.transcriptionRequestTimeout == 60)
+    #expect(NetworkDeadline.transcriptionRequestTimeout <= 120)
+  }
+
+  // MARK: - Hang → timeout
+
+  /// Never delivers a response. Cancellation arrives via `stopLoading`.
+  final class HangProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {}
+    override func stopLoading() {}
+  }
+
+  @Test("A request that never responds fails with requestTimeout instead of hanging")
+  func hangingRequestTimesOut() async {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [HangProtocol.self]
+    // URLSession's own timers must be longer than the deadline under test, otherwise
+    // a native timedOut could win and hide a broken Task deadline.
+    configuration.timeoutIntervalForRequest = 60
+    configuration.timeoutIntervalForResource = 300
+    let session = URLSession(configuration: configuration)
+    defer { session.invalidateAndCancel() }
+
+    let request = URLRequest(url: URL(string: "https://deadline.test/v1/audio/transcriptions")!)
+    let started = Date()
+    await #expect(throws: TranscriptionError.requestTimeout) {
+      _ = try await NetworkDeadline.data(for: request, session: session, timeout: 0.25)
+    }
+    let elapsed = Date().timeIntervalSince(started)
+    #expect(elapsed < 2, "deadline took \(elapsed)s; the hang path is still blocking")
+  }
+
+  // MARK: - Fast success
+
+  final class StubProtocol: URLProtocol {
+    nonisolated(unsafe) private static var bodies: [String: Data] = [:]
+    private static let lock = NSLock()
+
+    static func register(body: Data) -> URL {
+      let url = URL(string: "https://deadline.test/\(UUID().uuidString)")!
+      lock.lock()
+      bodies[url.absoluteString] = body
+      lock.unlock()
+      return url
+    }
+
+    private static func body(for url: URL?) -> Data? {
+      guard let key = url?.absoluteString else { return nil }
+      lock.lock()
+      defer { lock.unlock() }
+      return bodies[key]
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+      body(for: request.url) != nil
+    }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+      guard let url = request.url, let body = Self.body(for: url) else {
+        client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+        return
+      }
+      let response = HTTPURLResponse(
+        url: url, statusCode: 200, httpVersion: "HTTP/1.1",
+        headerFields: ["Content-Type": "application/json"])!
+      client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+      client?.urlProtocol(self, didLoad: body)
+      client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+  }
+
+  @Test("A response that arrives before the deadline is returned unchanged")
+  func fastResponseSucceeds() async throws {
+    let body = Data(#"{"text":"hello"}"#.utf8)
+    let url = StubProtocol.register(body: body)
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [StubProtocol.self]
+    let session = URLSession(configuration: configuration)
+    defer { session.invalidateAndCancel() }
+
+    let (data, response) = try await NetworkDeadline.data(
+      for: URLRequest(url: url), session: session, timeout: 5)
+    let http = try #require(response as? HTTPURLResponse)
+    #expect(http.statusCode == 200)
+    #expect(data == body)
+  }
+
+  // MARK: - Native URLSession timeout mapping
+
+  final class TimedOutProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+      client?.urlProtocol(self, didFailWithError: URLError(.timedOut))
+    }
+    override func stopLoading() {}
+  }
+
+  @Test("A URLSession-native timedOut is surfaced as TranscriptionError.requestTimeout")
+  func nativeTimedOutMapsToRequestTimeout() async {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [TimedOutProtocol.self]
+    let session = URLSession(configuration: configuration)
+    defer { session.invalidateAndCancel() }
+
+    let request = URLRequest(url: URL(string: "https://deadline.test/timeout")!)
+    await #expect(throws: TranscriptionError.requestTimeout) {
+      _ = try await NetworkDeadline.data(for: request, session: session, timeout: 5)
+    }
+  }
+
+  // MARK: - User-visible error
+
+  @Test("requestTimeout formats as a visible timeout, not a generic network error")
+  func requestTimeoutIsUserVisible() {
+    let message = SpeechErrorFormatter.format(.requestTimeout)
+    #expect(message.contains("Timeout"))
+    #expect(message.contains("too long"))
+    // Must not pin the copy to Gemini — OpenAI GPT-Transcribe throws this too.
+    #expect(!message.lowercased().contains("google"))
+    #expect(SpeechErrorFormatter.shortStatus(.requestTimeout).contains("Timeout"))
+  }
+}


### PR DESCRIPTION
Autonomous implementer build for queue row #1 (improvement-ledger I2, run 2, 2026-08-17).

**Proposal:** Find and fix the transcription hang — the `transcribing` phase could sit for 3.5–12.8 min before the user cancelled manually.
**Falsifier:** No `cancelledWhileProcessing` signal with `mode=transcription`, `detail.phase="transcribing"` and `gapMs > 120000` in the next two usage-review windows (baseline: 3 such signals 2026-08-10 → 2026-08-18, worst 12.8 min).

# Implementer notes — queue #1 (I2 transcription hang)

## What and why

Dictate using OpenAI GPT-Transcribe could sit in the `transcribing` phase for 3.5–12.8 minutes until the user cancelled. There was no error popup and no `errors-*.log` line, because the request had not failed — it was still waiting.

Root cause: the OpenAI-compatible multipart path set `URLRequest.timeoutInterval` to 300s (the resource timeout), which overrode the session's 60s request timer. `URLSession`'s own timers also do not reliably fire on reused HTTP/2 connections (OpenAI's API). Measured hangs outlasted 300s.

Fix: a wall-clock `NetworkDeadline` (60s) around that POST. A stall now throws `TranscriptionError.requestTimeout`, which already has a user-visible popup ("Request Timeout"), writes `stalled round-trip aborted` to `errors-*.log`, and emits a `requestTimedOut` outcome signal. The user no longer has to notice a frozen UI and cancel by hand.

This does not conflict with the current growth bottleneck (reach / App Store impressions). The 2026-08-18 growth review explicitly kept I2 as a customer-facing defect.

## How to verify by hand

1. Build this branch (do not install over `/Applications` until you want to). Confirm Settings → Dictate is on **GPT Transcribe** (or any OpenAI / xAI / self-hosted model — they share the multipart helper).
2. **Happy path:** Dictate a short sentence. Transcript should still land in ~1–5s, same as before. No timeout popup.
3. **Stall path (the actual fix):** block `api.openai.com` for this process (e.g. Little Snitch deny, or turn Wi-Fi off *after* the recording has stopped and the menu bar shows transcribing). After **60 seconds** you should get a **Request Timeout** popup, the menu bar should return to idle, and you should **not** have to press the shortcut again to unstick it.
4. Pressing the Dictate shortcut during those 60s should still cancel immediately (no timeout popup — cancellation stays silent).
5. Optional: after a forced timeout, confirm a new line in today's `errors-*.log` containing `stalled round-trip aborted` and a `requestTimedOut` row in `signals-YYYY-MM-DD.jsonl`.

## Falsifier

No `cancelledWhileProcessing` signal with `mode=transcription`, `detail.phase="transcribing"` and `gapMs > 120000` in the next two usage-review windows.

Baseline: 3 such signals between 2026-08-10 and 2026-08-18 (worst 12.8 min).

Queries:

```
# outcome signals (canonical)
~/Library/Containers/com.magnusgoedde.whispershortcut/Data/Library/Application Support/WhisperShortcut/UserContext/signals-*.jsonl

# hung-until-cancel (should be gone)
jq 'select(.kind=="cancelledWhileProcessing" and .mode=="transcription" and .detail.phase=="transcribing" and .gapMs>120000)'

# the fix firing (should appear if a stall happens)
jq 'select(.kind=="requestTimedOut" and .mode=="transcription")'

# error log
grep 'stalled round-trip aborted' …/UserContext/errors-*.log
```

A `requestTimedOut` row is success of this change, not a regression. A `cancelledWhileProcessing` with `gapMs > 120000` still in `transcribing` is a miss.

## Reviewer notes

- **No new setting, no default change, no migration, no new dependency.**
- Timeout is 60s wall-clock from request start (not idle-after-first-byte). Generous for normal dictation; a very long Dictate WAV on a slow uplink could now time out where it previously hung. Live Meeting is the long-audio path and is unchanged.
- OpenRouter chat-completions transcription is **not** wrapped; I2's evidence was GPT-Transcribe only. Same helper covers xAI and self-hosted because they share the multipart POST.
- `LLMHTTPSession` chat timeouts are unchanged.
- Tests added: `WhisperShortcutTests/NetworkDeadlineTests.swift` (hang → timeout, fast success, native `URLError.timedOut` mapping, user-visible copy, production cap ≤ 120s).
- Gates run here: `xcodebuild` Debug **BUILD SUCCEEDED**; `bash scripts/run-tests.sh` **TEST SUCCEEDED** (198 tests / 27 suites).

---

## Gates re-run by the runner

`xcodebuild` ✓ · full test plan ✓ · scope allowlist ✓ · clean tree ✓ · review by a **different model** (Opus): **APPROVE**

The reviewer confirmed the root cause (`request.timeoutInterval = 300s` overrode the session's 60s timer), that the concurrency is sound (`NetworkDeadline` is nonisolated, no new main-thread work on the audio path), and that the falsifier is measurable on ship day because the branch adds the `requestTimedOut` signal itself.

Merge = approval. The App Store release stays with the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
