### PR TITLE
Fix MLX download Cancel showing as a failed download

### DIFF
--- a/WhisperShortcut/ConnectionPrewarmer.swift
+++ b/WhisperShortcut/ConnectionPrewarmer.swift
@@ -113,6 +113,8 @@ enum ConnectionPrewarmer {
         let elapsedMs = (CFAbsoluteTimeGetCurrent() - startTime) * 1000
         DebugLogger.log(
           "PREWARM: MLX model \(mlxType.huggingFaceID) ready in \(String(format: "%.0f", elapsedMs))ms")
+      } catch is CancellationError {
+        DebugLogger.log("PREWARM: MLX model \(mlxType.huggingFaceID) warm-up cancelled")
       } catch {
         DebugLogger.logWarning(
           "PREWARM: MLX model \(mlxType.huggingFaceID) warm-up failed: \(error.localizedDescription)")

--- a/WhisperShortcut/LocalLLMModelManager.swift
+++ b/WhisperShortcut/LocalLLMModelManager.swift
@@ -112,7 +112,10 @@ final class LocalLLMModelManager: ObservableObject {
     return nil
   }
 
-  private static let requiredFileNames = ["config.json"]
+  /// `tokenizer.json` is required because Hub snapshot can finish `config.json` + the
+  /// `.safetensors` shard and still be cancelled before the tokenizer lands. Treating that
+  /// half-repo as "available" made Delete appear and the first load fail.
+  private static let requiredFileNames = ["config.json", "tokenizer.json"]
 
   private func hasRequiredMLXFiles(at directory: URL) -> Bool {
     guard Self.requiredFileNames.allSatisfy({
@@ -236,18 +239,24 @@ final class LocalLLMModelManager: ObservableObject {
         }
       }
 
+      // Hub 1.1.9's snapshot returns the repo URL when `Task.isCancelled` after a file,
+      // instead of throwing. Catch that before we treat a partial tree as success.
+      try Task.checkCancellation()
+
       guard hasRequiredMLXFiles(at: dir) || isModelAvailable(type) else {
         throw LocalLLMModelError.downloadFailed(
           "Model downloaded but required files are missing. Please try again.")
       }
 
       DebugLogger.logSuccess("LOCAL-LLM-MANAGER: \(type.displayName) downloaded successfully")
-    } catch is CancellationError {
-      DebugLogger.log("LOCAL-LLM-MANAGER: Download cancelled for \(type.huggingFaceID)")
-      throw CancellationError()
-    } catch let error as LocalLLMModelError {
-      throw error
     } catch {
+      if Self.isCancellation(error) {
+        DebugLogger.log("LOCAL-LLM-MANAGER: Download cancelled for \(type.huggingFaceID)")
+        throw CancellationError()
+      }
+      if let error = error as? LocalLLMModelError {
+        throw error
+      }
       DebugLogger.logError("LOCAL-LLM-MANAGER: Download failed: \(error.localizedDescription)")
       throw LocalLLMModelError.downloadFailed(error.localizedDescription)
     }
@@ -294,6 +303,17 @@ enum LocalLLMModelError: LocalizedError {
     case .downloadFailed(let message): return "Download failed: \(message)"
     case .fileError(let message): return "File error: \(message)"
     }
+  }
+}
+
+extension LocalLLMModelManager {
+  /// Hub's per-file downloader cancels the URLSession with `URLError.cancelled`; Swift
+  /// concurrency uses `CancellationError`. Both must stay silent in the Settings UI.
+  fileprivate static func isCancellation(_ error: Error) -> Bool {
+    if error is CancellationError { return true }
+    if let urlError = error as? URLError, urlError.code == .cancelled { return true }
+    let nsError = error as NSError
+    return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
   }
 }
 

--- a/WhisperShortcut/MenuBarController.swift
+++ b/WhisperShortcut/MenuBarController.swift
@@ -2028,6 +2028,8 @@ class MenuBarController: NSObject {
       do {
         try await LocalLLMModelManager.shared.ensureReadyWithUI(type, title: "Offline MLX")
         DebugLogger.logSuccess("MENU-BAR: MLX model \(type.displayName) ready")
+      } catch is CancellationError {
+        DebugLogger.log("MENU-BAR: MLX prepare cancelled for \(type.displayName)")
       } catch {
         DebugLogger.logError(
           "MENU-BAR: Could not prepare MLX \(type.displayName): \(error.localizedDescription)")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Review of in-process MLX on `feat/local-llm-mlx` @ `0fe7e4d` (PR 46). Cancel **does** abort the Hub transfer (swift-transformers 1.1.9 `HubFileDownloader` cancels the URLSession). Two concrete bugs around that path:

1. **Cancel was shown as a failed download.** Hub throws `URLError.cancelled` mid-file, and after a finished file `snapshot` returns the repo URL when `Task.isCancelled` instead of throwing. The Settings catch only ignored `CancellationError`, so Cancel painted a red "Download failed: cancelled" (or "required files are missing").
2. **A cancelled download could look Downloaded.** Required files were only `config.json` + any `.safetensors`. On these catalogue repos the big shard lands *before* `tokenizer.json`, so Cancel after the weights but before the tokenizer marked the row available and the first load failed.

This PR maps Hub cancel to `CancellationError` (so the existing UI catch stays silent), checks cancellation after snapshot returns, and requires `tokenizer.json` before a model is "available". Menu-bar / prewarm no longer log cancel as an error.

## Review findings (not changed)

- Catalogue IDs/sizes match: `mlx-community/Qwen3-4B-Instruct-2507-4bit` (~2.3 GB) and `mlx-community/Qwen3-8B-4bit` (~4.5 GB).
- Download vs load is split: `downloadModel` only fetches files; one `MLXModelLoader` actor on `LocalLLMModelManager`; `MLXChatProvider` has no private loader.
- Chat and Dictate share that container. The pre-`0fe7e4d` double-instantiation (provider-owned loader) is gone.
- Hub progress is **file-count** (`Progress(totalUnitCount: filenames.count)`), with per-file byte progress as an equal-weight child. 4B has 10 matching files (bar moves ~10% per file; the 2.3 GB shard is ~40–50%). 8B has 8 matching files (~12.5% each; shard ~25–37.5%). Looks stuck during the big file. Byte-weighted progress is upstream PR huggingface/swift-transformers#369 — cannot take it without moving the 1.1.9 pin.
- Tests still cover catalogue/mapping only.

## Residual risks (not bugs to fix here)

- 8B (~4.5 GB weights) will use a large amount of unified memory once loaded.
- Cancel during RAM load is not offered in the UI (`downloadingModels` is download-only). The loader’s unstructured `loadModel` Task is not cancelled if `readyTasks` is cancelled at the download→load boundary.
- `ensureReadyWithUI` in `MLXChatProvider` flashes "Offline Chat" and dismisses the dictate progress popup when Dictate Prompt re-enters the stream.

## Test plan

- [ ] Settings → Available Models → Download Qwen3 4B → Cancel during the large `.safetensors` (progress sitting in the 40–50% band). Row returns to "Not downloaded", no red error, no success popup.
- [ ] Cancel after the shard finishes but before `tokenizer.json`. Must **not** show Delete / Downloaded.
- [ ] Download to completion still shows the success popup and a later Delete.
- [ ] Pick the model so menu-bar `ensureReadyWithUI` starts the download; Cancel from the bar above the tiles. No "Could not prepare MLX" error log.

WhisperKit, the swift-transformers 1.1.9 pin, and Ollama are untouched.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c36c652c-7c0f-4302-a5a2-a81af2d58bab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c36c652c-7c0f-4302-a5a2-a81af2d58bab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

