### PR TITLE
Stop shortcut rendering from aborting the process on concurrent access

### DIFF
--- a/WhisperShortcut/ShortcutConfig.swift
+++ b/WhisperShortcut/ShortcutConfig.swift
@@ -256,7 +256,32 @@ struct ShortcutDefinition: Codable, Equatable, Hashable {
   /// legacy stored shortcut has no `displayCharacter`. Returns `nil` for
   /// non-printable keys (arrows, function keys, etc.) — caller should fall back
   /// to `Key.displayString` in that case.
+  /// Serializes the Carbon Text Input Source calls below.
+  ///
+  /// `TISGetInputSourceProperty` is not safe to call concurrently: HIToolbox validates the ref
+  /// against a process-global input-source list, and two threads in there at once trips its own
+  /// assertion and calls `abort()`. That is a hard SIGABRT of the whole process, not an error
+  /// return — verified from the crash report:
+  ///
+  ///     abort
+  ///     HIToolbox  islGetInputSourceListWithAdditions.cold.3
+  ///     HIToolbox  isValidateInputSourceRef
+  ///     HIToolbox  TSMGetInputSourceProperty
+  ///     ShortcutDefinition.layoutAwareCharacter(forCarbonKeyCode:)
+  ///
+  /// It killed the CI test host from v8.06 on, roughly half of all runs: swift-testing runs suites
+  /// in parallel, so several of them rendered a `displayString` at once. It was invisible in the
+  /// log because xcodebuild attributes a host crash to the last test that *completed* — it kept
+  /// naming `SettingsSlotRoundTripTests`, a suite earlier, which passes.
+  ///
+  /// A lock rather than a main-thread hop or a cache on purpose: the concurrency was entirely our
+  /// own, serializing it is the whole fix, and it keeps this reading the live layout so switching
+  /// keyboard layout still updates what a binding renders as.
+  private static let tisLock = NSLock()
+
   fileprivate static func layoutAwareCharacter(forCarbonKeyCode keyCode: UInt32) -> String? {
+    tisLock.lock()
+    defer { tisLock.unlock() }
     guard let inputSource = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue() else {
       return nil
     }

--- a/WhisperShortcutTests/ShortcutDisplayTests.swift
+++ b/WhisperShortcutTests/ShortcutDisplayTests.swift
@@ -10,6 +10,29 @@ import Testing
 @Suite("Shortcut display")
 struct ShortcutDisplayTests {
 
+  /// Rendering a shortcut used to abort the whole process when two threads did it at once:
+  /// `layoutAwareCharacter` calls `TISGetInputSourceProperty`, and HIToolbox validates the ref
+  /// against a process-global list that is not safe for concurrent access — it trips its own
+  /// assertion and calls `abort()`. Nothing in this file failed; the test *host* died, and
+  /// xcodebuild blamed whichever test had last completed.
+  ///
+  /// This crashed reliably before `tisLock` and passes in milliseconds after it. A regression
+  /// shows up as the host disappearing mid-run rather than as a clean failure, which is exactly
+  /// the signal that went unread for four releases.
+  @Test("Rendering from many threads at once does not abort the process")
+  func concurrentRenderingIsSafe() async {
+    let keys: [Key] = [.f17, .f13, .f20, .f1, .a, .space, .comma, .period]
+    await withTaskGroup(of: Void.self) { group in
+      for i in 0..<500 {
+        group.addTask {
+          let definition = ShortcutDefinition(key: keys[i % keys.count], modifiers: [])
+          _ = definition.displayString
+          _ = definition.displayStringWithSeparator
+        }
+      }
+    }
+  }
+
   @Test("Bare function keys render as their name")
   func bareFunctionKey() {
     // F13–F20 are what programmable keyboards send for a dedicated key, and they are bindable


### PR DESCRIPTION
Fixes the flaky test-host crash that has reddened CI and the release pipeline since v8.06.

## Root cause — confirmed, not inferred

`ShortcutDefinition.layoutAwareCharacter` calls `TISGetInputSourceProperty` on every render. That call is not safe to make concurrently: HIToolbox validates the input-source ref against a process-global list, and two threads in there at once trips its own assertion and calls `abort()` — a hard SIGABRT of the whole process, not an error return.

The crash report:

```
abort
HIToolbox   islGetInputSourceListWithAdditions.cold.3
HIToolbox   isValidateInputSourceRef
HIToolbox   TSMGetInputSourceProperty
ShortcutDefinition.layoutAwareCharacter(forCarbonKeyCode:)
ShortcutDefinition.displayString.getter
```

swift-testing runs suites in parallel, so more than one rendered a `displayString` at once. `-parallel-testing-enabled NO` in `run-tests.sh` does not disable that — it governs parallel *destinations*, not swift-testing's in-process concurrency.

## Why it went unread for four releases

xcodebuild attributes a host crash to the last test that **completed**, not the one that was running. It kept reporting `SettingsSlotRoundTripTests.everySlotPersists()`, which the same log shows passing in 2.965 s, one suite before the real crash site. The only honest line in the output is `Restarting after unexpected exit, crash, or test timeout`.

## The fix

An `NSLock` around the Carbon calls. Deliberately a lock rather than a main-thread hop or a cached layout:

- the concurrency was entirely our own, so serializing it is the whole fix;
- it keeps reading the live layout, so switching keyboard layout still updates what a binding renders as — a cache would go stale until relaunch.

## Verification

- Reproduced deterministically first: 500 concurrent `displayString` calls killed the test host locally, twice, with the backtrace above.
- With the lock, the same 500 calls pass in 5 ms.
- Full hermetic plan: 343 tests in 46 suites pass; `rebuild-and-restart.sh` clean.

The regression test ships in `ShortcutDisplayTests`. Worth knowing its failure signature: a regression kills the test host rather than failing cleanly, so watch for `Restarting after unexpected exit` rather than a named failure.

Companion to the CI change already on main, which now dumps crash reports into the job log and uploads the `.xcresult` on failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)