### PR TITLE
Make everySlotPersists actually test persistence

### DIFF
--- a/WhisperShortcutTests/SettingsSlotRoundTripTests.swift
+++ b/WhisperShortcutTests/SettingsSlotRoundTripTests.swift
@@ -43,6 +43,7 @@ struct SettingsSlotRoundTripTests {
     UserDefaultsKeys.selectedReadAloudVoiceGemini,
     UserDefaultsKeys.selectedReadAloudVoiceOpenAI,
     UserDefaultsKeys.selectedReadAloudVoiceXAI,
+    UserDefaultsKeys.selectedReadAloudVoiceSystem,
     UserDefaultsKeys.chatCloseOnFocusLoss,
     UserDefaultsKeys.settingsCloseOnFocusLoss,
     UserDefaultsKeys.liveMeetingChunkInterval,
@@ -99,6 +100,7 @@ struct SettingsSlotRoundTripTests {
     data.readAloudVoiceGemini = "probe-gemini-voice"
     data.readAloudVoiceOpenAI = "probe-openai-voice"
     data.readAloudVoiceXAI = "probe-xai-voice"
+    data.readAloudVoiceSystem = "probe-system-voice"
     data.chatCloseOnFocusLoss = !SettingsDefaults.chatCloseOnFocusLoss
     data.settingsCloseOnFocusLoss = !SettingsDefaults.settingsCloseOnFocusLoss
     data.liveMeetingChunkInterval = .thirtySeconds
@@ -135,22 +137,37 @@ struct SettingsSlotRoundTripTests {
     }
   }
 
+  /// The whole-table `roundTripIsIdentity` above can hide a broken slot: it saves and loads
+  /// *every* slot, so one that reads a key nobody wrote still lands on the value some other slot
+  /// happened to leave behind. This drives each slot alone against a cleared UserDefaults.
+  ///
+  /// The comparison is against the slot's own **no-op baseline** — what it loads when nothing was
+  /// persisted — rather than against a second load of the same state. Comparing two identical
+  /// loads is what this test used to do, and it made the test vacuous: both sides ran the same
+  /// code over the same bytes, so it passed even when `save` wrote nothing at all. Every probe
+  /// value differs from its default (see `makeProbe`), so a slot that genuinely persisted
+  /// something cannot match its baseline.
   @Test("Each slot writes something a reload can actually see")
   func everySlotPersists() {
     preservingDefaults {
       let probe = makeProbe()
       for (index, slot) in SettingsViewModel.slots.enumerated() {
+        // What this slot yields with nothing persisted.
         for key in Self.touchedKeys { UserDefaults.standard.removeObject(forKey: key) }
+        var baseline = SettingsData()
+        slot.load(&baseline)
 
+        // What it yields after saving the probe, from the same cleared starting point.
+        for key in Self.touchedKeys { UserDefaults.standard.removeObject(forKey: key) }
         slot.save(probe)
         var loaded = SettingsData()
         slot.load(&loaded)
 
-        // A slot whose save and load disagree on the key leaves `loaded` at the default, which
-        // differs from the probe for every field — that is exactly the drift this catches.
-        var expected = SettingsData()
-        slot.load(&expected)
-        #expect(loaded == expected, "slot \(index) did not round-trip in isolation")
+        // A slot whose save and load disagree on the key leaves `loaded` at the default — equal
+        // to the baseline. That is exactly the drift this catches.
+        #expect(
+          loaded != baseline,
+          "slot \(index) wrote nothing its own load could see — check that save and load use the same key")
       }
     }
   }


### PR DESCRIPTION
`everySlotPersists` could not fail. It compared `loaded` against `expected`, but built both the same way — a fresh `SettingsData()` followed by `slot.load(...)`:

```swift
var loaded = SettingsData()
slot.load(&loaded)

var expected = SettingsData()
slot.load(&expected)
#expect(loaded == expected)
```

Two identical loads over the same bytes. The assertion held regardless of what `save` did, including nothing at all — the one thing the test's name promises to catch.

## The fix

Compare against the slot's own **no-op baseline**: what it loads when nothing was persisted, from the same cleared UserDefaults. Every probe value differs from its default (per `makeProbe`'s contract), so a slot that genuinely persisted something cannot match its baseline.

**Verified by mutation, not by assertion.** Making one slot's `save` a no-op now fails with:

```
slot 1 wrote nothing its own load could see — check that save and load use the same key
```

The old version passed that same sabotage. Sabotage reverted before commit.

## What it caught immediately

`readAloudVoiceSystem` (slot 24) had joined the slot table without joining the test fixtures:

- **`makeProbe()` never set it**, so its probe value *was* the default. Both halves of every comparison agreed by accident, which means the slot was untested here — including by the whole-table `roundTripIsIdentity`, since a slot reading a key nobody wrote still lands on the default.
- **`touchedKeys` never listed `selectedReadAloudVoiceSystem`**, so the suite neither cleared it before the run nor restored it after — leaking the developer's real setting into the test and leaving it modified afterwards.

Both added. This is precisely the drift the suite was built to prevent, and it went unnoticed because the check meant to catch it could not fail.

## Verification

- Full hermetic plan: 343 tests in 46 suites pass
- `rebuild-and-restart.sh` clean
- Diff is test-only — no production code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)