### PR TITLE
Give the implementer a schedule, a groomer and a veto lane

### DIFF
--- a/plans/agent-loops.md
+++ b/plans/agent-loops.md
@@ -23,7 +23,7 @@ last, however good it looks locally.
 | **Models** | `model-audit-job.sh` (`audit-llm-models`) | Live provider lineups vs shipped defaults, benchmarks | Pareto-justified migrations | `plans/model-audits/` | Wed 09:17 monthly |
 | **Strategy/Growth** | `growth-review-job.sh` (`review-growth`) | App Store Connect, GitHub, git effort, competitors | Naming the ONE binding constraint toward revenue | `../business/growth-ledger.md` + digest | Sat 09:07, effectively biweekly |
 | **Architect** | `agent-loops-job.sh` (`review-agent-loops`) | The loops' own ledgers, hit rates, blind spots, outside best practices, Sabaki's loop docs | The loops finding more true things per run | `plans/loop-ledger.md` + digest | 6th of month, 10:17 |
-| **Implementer** | `run-implementer.sh` (`implement-proposal`) — **rung 2** | One flagged queue row + its source ledger entry | A gated, reviewed branch you can dogfood | Code on a branch, `plans/implementer-{queue,log}.md` | On demand (`BUILD` flag + manual invocation) |
+| **Implementer** | `tick.sh` → `groom-queue.py` + `run-implementer.sh` (`implement-proposal`) — **rung 2** | One released queue row + its source ledger entry | A gated, reviewed branch you can dogfood | Code on a branch, `plans/implementer-{queue,log}.md` | Hourly tick (launchd); builds a row you flagged `BUILD`, or one whose veto window ran out |
 | **Sales** | parent `scripts/sales/scout-job.sh` (`run-sales-agent`) — scout **rung 0**; poster **rung 3** | Public HN/Reddit/GitHub/App Store conversations | Disclosed drafts that route people to the store; customer-voice feedback | `../sales/ops/` (private parent — queue, digests, feedback). Never the public app repo | Daily 08:17 scout, 15:05 poster |
 
 ## Shared conventions (kept identical with sabaki.dance — do not drift)
@@ -63,7 +63,8 @@ Two capabilities are above rung 0:
 
 | Capability | Rung | Gate that holds it there |
 | ---------- | ---- | ------------------------ |
-| Implementer: build a flagged queue row → gated branch | **2** | The *runner* re-runs every gate (scope allowlist, clean tree, main-checkout pollution, `xcodebuild`, full test plan); a **different model** reviews the diff; `IMPLEMENTER_ENABLED` kill switch read at run time; nothing is pushed or released; only rows a human flagged `BUILD` are eligible. Reversibility: everything it produces is a local branch. |
+| Implementer: build a released queue row → gated branch | **2** | The *runner* re-runs every gate (scope allowlist, clean tree, main-checkout pollution, `xcodebuild`, full test plan); a **different model** reviews the diff; `IMPLEMENTER_ENABLED` and `IMPLEMENTER_TICK_ENABLED` kill switches read at run time; nothing is merged or released. A row is released either by you flagging it `BUILD`, or by a **veto window** running out (below). Reversibility: everything it produces is a branch and a PR you merge. |
+| Groomer: file a loop proposal as a `VETO` row that builds on silence | **2** | `groom-queue.py` contains no model — every lane is a lookup or a regex against committed state. Only reversible, in-scope classes with a gradeable falsifier get a window; `instrumentation` needs an OPEN row in `plans/instrumentation-gaps.md`; everything else lands in `ASK`. At most `IMPLEMENTER_MAX_INFLIGHT` (3) auto rows open at once, and every window is announced by mail before it starts. Kill switch `IMPLEMENTER_VETO_LANE=0` restores the pre-2026-09-03 behaviour. |
 | Sales poster: comment on a public thread or App Store review | **3** | Morning digest is the preview; 15:05 posts PREVIEWED rows whose veto window elapsed (`SALES_VETO_HOURS`, default 7). `../scripts/sales/veto.sh S-001` stops a row. Kill switch `SALES_POST_ENABLED` (default 0). A comment to a stranger is irreversible, so this capability does not promote to rung 4. |
 
 The rule that outranks every finding, from the same policy:
@@ -71,6 +72,14 @@ The rule that outranks every finding, from the same policy:
 > **An agent may tighten a gate, never loosen one.** Adding a check, raising an evidence
 > bar, demanding a falsifier: propose freely. Removing a falsifier, relaxing a threshold,
 > lowering a sample floor: a human change, in its own commit.
+
+The `VETO` lane is the one loosening this repo has taken, and it was taken the way the rule
+requires: asked and answered by the owner on **2026-09-03**, in its own commit, with a kill
+switch (`IMPLEMENTER_VETO_LANE=0`). What it changes is who must act — before, a proposal
+nothing could prove waited for approval that never came (queue row 2 has sat `OPEN` since
+2026-08-20); now it waits for an objection. What it does **not** change is any gate on the code
+itself: the runner still re-runs every check, a different model still reviews the diff, and the
+output is still a PR you merge.
 
 And its corollary for the Architect loop specifically: it proposes changes to the loop
 machinery, it never applies them unattended — an agent that edits the criteria it is judged
@@ -83,7 +92,15 @@ The shape is theirs; three things differ because this repo is a sandboxed macOS 
 web service (see the divergence table below).
 
 ```
-plans/implementer-queue.md          ← YOU set Flag=BUILD (no agent may)
+loop jobs (usage · model-audit · growth · architect)
+        │ each run drops proposals.json in ~/.local/state/whispershortcut-implementer/incoming
+        ▼
+scripts/implementer/tick.sh         ← hourly under launchd
+        │ groom-queue.py: lookups only, no model. instrumentation w/ an OPEN gap → BUILD;
+        │ reversible+in-scope+falsifiable → VETO (announced by mail, builds on silence);
+        │ everything else → ASK. Ripe VETO windows promote to BUILD.
+        ▼
+plans/implementer-queue.md          ← YOU set Flag=BUILD, or stop a VETO row: veto.sh <#>
         │
 scripts/implementer/run-implementer.sh
         │ 1. kill switch, lock, main-branch check, pick topmost BUILD/OPEN row
@@ -102,9 +119,17 @@ YOU run the branch build for a while → merge → release when you decide
 
 ```bash
 bash scripts/implementer/install-implementer.sh    # once: ~/.config/whispershortcut-implementer/env
+bash scripts/implementer/install-tick.sh           # once: the hourly launchd agent
 bash scripts/implementer/run-implementer.sh --dry-run
-bash scripts/implementer/run-implementer.sh
+bash scripts/implementer/run-implementer.sh        # one build, by hand
+
+python3 scripts/implementer/groom-queue.py --dry-run   # what would the groomer file?
+bash scripts/implementer/veto.sh 7                     # stop VETO row 7 before its deadline
 ```
+
+Both switches must be `1` in `~/.config/whispershortcut-implementer/env` before the schedule
+does anything: `IMPLEMENTER_ENABLED` (master) and `IMPLEMENTER_TICK_ENABLED` (schedule only).
+Tick log: `build/logs/implementer/tick-<date>.log`.
 
 **The rules that keep it honest** — all mirrored from Sabaki, all enforced in the script:
 
@@ -115,7 +140,11 @@ bash scripts/implementer/run-implementer.sh
 - **Measurable-on-ship-day.** A row whose falsifier cannot be measured when it ships is not
   eligible; the build must add the instrumentation in the same branch, or the proposal goes to
   `plans/instrumentation-gaps.md` first.
-- **Flagging is human.** No loop and no agent may set `BUILD`. Loops propose into ledgers.
+- **Releasing is human, or it is silence.** No loop may set `BUILD` on its own finding — only
+  the groomer may, and only for classes an existing gate judges. Everything else it files is
+  either a `VETO` row you were mailed about and can stop, or an `ASK` row that waits for you.
+- **Nothing is ever dropped.** A proposal the groomer cannot justify becomes an `ASK` row, not
+  a discarded finding. That is what makes the ASK lane safe to be conservative with.
 - **Demotion falsifier:** ≥2 of any 5 consecutive runs needing structural rework → back to
   rung 1. Tracked in `plans/implementer-log.md`, graded from its Outcome column.
 - **Promotion is earned:** 5 clean merges before `IMPLEMENTER_SELF_PICK=1` is even offered, and
@@ -129,7 +158,7 @@ changes, re-measure it rather than editing the prose.
 | Surface | Billed as | Per run | Brake |
 | --- | --- | --- | --- |
 | The four scheduled Claude jobs | **Max subscription** — no `ANTHROPIC_API_KEY` anywhere, so they spend rate-limit capacity, not dollars | $0 | `--max-budget-usd` (3–10) is a backstop that only binds if an API key ever enters the environment |
-| Implementer build agent | **Cursor subscription**, model `auto` (the Auto/Composer pool, not the API pool) | quota only | 120-min per-run timeout · **10 runs/month** (`IMPLEMENTER_MAX_RUNS_PER_MONTH`) |
+| Implementer build agent | **Cursor subscription**, model `auto` (the Auto/Composer pool, not the API pool) | quota only | 120-min per-run timeout · **10 runs/month** (`IMPLEMENTER_MAX_RUNS_PER_MONTH`) · one build per tick, and only when a row is actually released |
 | Implementer review pass | Max subscription (Opus) | $0 | one rework cycle, then the run stops |
 | Implementer test gate | **Real dollars** — the live roundtrip tests use the provider keys in `.env` | 5 requests × 1.24 s audio ≈ **under $0.01** | gated per credential; tests skip when a key is absent |
 | Monthly model audit | Real dollars, same keys | ~400 short transcription requests ≈ **a few cents** | monthly cadence |
@@ -137,6 +166,14 @@ changes, re-measure it rather than editing the prose.
 | `web-traffic-report.sh` | **$0 marginal** — Cloud Logging *reads* are free; Cloud Run was already writing those logs | $0 | `--limit 20000` |
 
 **Total real-dollar exposure of the whole loop system: well under $1/month** at current cadences.
+
+**The hourly tick does not mean hourly builds.** A tick with no released row exits in under a
+second: the runner prints "no BUILD/OPEN row in the queue" and stops before any agent starts.
+What bounds the spend is unchanged and is not the schedule — it is `IMPLEMENTER_MAX_RUNS_PER_MONTH`
+(10), counted in a file so it survives a crash mid-run, plus `IMPLEMENTER_MAX_INFLIGHT` (3) on
+how many rows the groomer may have released at once. The schedule only removes the requirement
+that you be at the keyboard for a build you already agreed to.
+
 
 **Two of the three billing surfaces are now closed by construction, not by luck:**
 
@@ -205,6 +242,8 @@ Sabaki):
 | "Live" check | `deployment-status.ts` against `/api/version` | App Store version (`asc versions list`) / GitHub release for customer metrics; rebuilt local app for own-usage metrics | Different deploy targets, same deploy gate |
 | Implementer review surface | Branch deployed to a gated dev instance with sanitized prod data | The built app itself — you run the branch build (dogfood-as-review) | No server, no database; the app *is* the artifact |
 | Implementer test gate | `npm run test:web` in the worktree | `xcodebuild test`, which requires killing the running app — the runner relaunches the user's **main** build afterwards, never the branch build | An unattended run must never swap the app the user works in |
+| Implementer auto lane | `scorer-fix` (a failing eval-corpus case is red→green) and `instrumentation` build with no announcement | `instrumentation` only — there is no eval corpus here | The auto lane may only hold classes an existing gate already judges; inventing one to match Sabaki would be the loosening the policy forbids |
+| Proposal transport | routines write JSON to `~/.local/state/sabaki-implementer/incoming`, groomer is TypeScript | identical shape, groomer is Python (`groom-queue.py`) | No node toolchain in a Swift repo; a dependency nobody maintains is a scheduled job that dies silently |
 
 ## Operating
 

--- a/plans/implementer-queue.md
+++ b/plans/implementer-queue.md
@@ -1,12 +1,32 @@
 # Implementer Queue
 
 Input queue of the autonomous implementer (`scripts/implementer/run-implementer.sh`,
-architecture: `plans/agent-loops.md`). **You** add a row and set `Flag=BUILD` to release it;
-the runner takes the **topmost** eligible row (`Flag=BUILD`, `Status=OPEN`), one per run.
+architecture: `plans/agent-loops.md`). Rows arrive two ways: **you** write one by hand, or
+`scripts/implementer/groom-queue.py` files one from a loop's proposal. The hourly tick
+(`scripts/implementer/tick.sh`) grooms the queue and then builds the **topmost** eligible row
+(`Flag=BUILD`, `Status=OPEN`), one per run.
 
 The runner never edits this file in the main checkout — it flips the row to
 `Status=BRANCH <name>` (or `PR <url>`) **on its own branch**, so the bookkeeping travels with
-the code and your merge closes the loop.
+the code and your merge closes the loop. The groomer is the one exception: it commits its rows
+on `main`, because a proposal filed on a branch nobody merges is a proposal nobody sees.
+
+**The four lanes — the difference is who may release a row**
+
+| Flag | Meaning |
+| ---- | ------- |
+| `BUILD` | builds unattended on the next tick. Written by the groomer for gate-covered classes only (`instrumentation`), or by you for anything. |
+| `VETO` | announced by mail with a **Deadline**, then promoted to `BUILD` on silence. Your only job is to stop it: `bash scripts/implementer/veto.sh <#>` moves it to `ASK`. Silence is a yes. |
+| `ASK` | needs your decision — irreversible, out of scope, or no falsifier a checker can parse. The groomer files everything it cannot justify here; it never drops a proposal. |
+| `HOLD` | parked by you. The groomer never touches a `HOLD` row. |
+
+**Why a VETO lane.** Two lanes made you the gate: every proposal the machinery could not prove
+landed on your desk, and the rows below show what that produced — row 2 has sat `OPEN` since
+2026-08-20. Sabaki hit the same wall on 2026-08-27 (20 undecided rows in one day) and answered
+it the same way: do not ask for approval, make disagreement possible. Adding this lane loosened
+a gate, so per `plans/agent-loops.md` it was a human decision, taken 2026-09-03.
+
+Status: `OPEN` · `BRANCH <name>` · `PR <url>` · `MERGED` · `DROPPED`.
 
 **Eligibility rules**
 
@@ -16,14 +36,12 @@ the code and your merge closes the loop.
   metric does not exist yet, the build must add the instrumentation in the same branch
   (`DebugLogger` / interaction-log / outcome-signal write) and name the exact query that will
   grade it. Otherwise it belongs in `plans/instrumentation-gaps.md` first.
-- Flagging is a deliberate human act. No loop and no agent may set `BUILD` — they propose into
-  the ledgers, you decide what gets built.
+- **No model decides a lane.** `groom-queue.py` contains lookups and regexes, never a judgement
+  call — a loop says what its proposal *is* (`class`), the groomer decides what that class is
+  allowed to do. Widening `AUTO_CLASSES` or the veto windows is a human commit.
 
-Flags: `HOLD` (parked, needs your decision) · `BUILD` (released to the runner).
-Status: `OPEN` · `BRANCH <name>` · `PR <url>` · `MERGED` · `DROPPED`.
-
-| #   | Source | Proposal (one line) | Falsifier | Flag | Status |
-| --- | ------ | ------------------- | --------- | ---- | ------ |
-| 1 | improvement-ledger I2 (run 2, 2026-08-17) | Find and fix the transcription hang: the `transcribing` phase can sit for 3.5–12.8 min before the user cancels manually — add/repair the request timeout on the OpenAI GPT-Transcribe path so a stalled round-trip fails fast with a visible error instead of an unresponsive UI | No `cancelledWhileProcessing` signal with `mode=transcription`, `detail.phase="transcribing"` and `gapMs > 120000` in the next two usage-review windows (baseline: 3 such signals between 2026-08-10 and 2026-08-18, worst 12.8 min) | BUILD | MERGED |
-| 2 | improvement-ledger I3 + instrumentation-gaps #8 (investigated 2026-08-20) | Close instrumentation gap #8: make `noSpeechDetected` visible to the outcome-signal stream. Add an `OutcomeSignal.noSpeechDetected` case (`ContextLogger.swift`) and emit it from BOTH paths — the local silence gate (`MenuBarController.swift:2432`, which skips the API call) and the API-empty path (`SpeechService.swift:2002`/`:2012`) — carrying `detail.source` (`localSilenceGate` or `apiEmptyResult`), `detail.peakDb`, `detail.durationMs` and `detail.logPrefix`. Follow the `requestTimedOut` precedent from PR #45. **Instrumentation only — do not change the gate threshold or any recording behaviour** | Over the next two usage-review windows, every `noSpeechDetected` occurrence counted in `errors-*.log` has a matching `noSpeechDetected` record in `interactions-*.jsonl` with all four fields non-null, and `detail.logPrefix` separates the `MEETING-SEGMENT` occurrences from the dictation ones. Falsified if the two counts still diverge, if any field is absent, or if the meeting/dictation split still cannot be read. Baseline: 39 error-log occurrences vs 0 interaction records (2026-07-22…2026-08-20); 30 dictation / 9 meeting | HOLD | OPEN |
-| 3 | improvement-plan F15 (parked 2026-09-02) | Streaming local Dictate: admit Whisper in `DictateStreamingSession.makeIfEligible` so Offline Mode transcribes chunks while recording, with the existing merged-WAV fallback. **Do not add a Parakeet-class model in this row.** See `plans/active/streaming-dictate.md` slice 4. | A ≥20 s Offline Whisper dictation logs `SPEED: STREAMING-DICTATE: Transcript ready` and stop-to-clipboard is closer to last-chunk time than to full-file Whisper; a failed in-flight chunk still pastes via the merged-WAV fallback. Falsified if WhisperKit hangs/OOM during recording, or if chunk seams hallucinate after F14's peak gate. | BUILD | BRANCH claude/local-speech-to-text-optimize-0da93d |
+| #   | Source | Proposal (one line) | Falsifier | Flag | Status | Deadline |
+| --- | ------ | ------------------- | --------- | ---- | ------ | -------- |
+| 1 | improvement-ledger I2 (run 2, 2026-08-17) | Find and fix the transcription hang: the `transcribing` phase can sit for 3.5–12.8 min before the user cancels manually — add/repair the request timeout on the OpenAI GPT-Transcribe path so a stalled round-trip fails fast with a visible error instead of an unresponsive UI | No `cancelledWhileProcessing` signal with `mode=transcription`, `detail.phase="transcribing"` and `gapMs > 120000` in the next two usage-review windows (baseline: 3 such signals between 2026-08-10 and 2026-08-18, worst 12.8 min) | BUILD | MERGED |  |
+| 2 | improvement-ledger I3 + instrumentation-gaps #8 (investigated 2026-08-20) | Close instrumentation gap #8: make `noSpeechDetected` visible to the outcome-signal stream. Add an `OutcomeSignal.noSpeechDetected` case (`ContextLogger.swift`) and emit it from BOTH paths — the local silence gate (`MenuBarController.swift:2432`, which skips the API call) and the API-empty path (`SpeechService.swift:2002`/`:2012`) — carrying `detail.source` (`localSilenceGate` or `apiEmptyResult`), `detail.peakDb`, `detail.durationMs` and `detail.logPrefix`. Follow the `requestTimedOut` precedent from PR #45. **Instrumentation only — do not change the gate threshold or any recording behaviour** | Over the next two usage-review windows, every `noSpeechDetected` occurrence counted in `errors-*.log` has a matching `noSpeechDetected` record in `interactions-*.jsonl` with all four fields non-null, and `detail.logPrefix` separates the `MEETING-SEGMENT` occurrences from the dictation ones. Falsified if the two counts still diverge, if any field is absent, or if the meeting/dictation split still cannot be read. Baseline: 39 error-log occurrences vs 0 interaction records (2026-07-22…2026-08-20); 30 dictation / 9 meeting | HOLD | OPEN |  |
+| 3 | improvement-plan F15 (parked 2026-09-02) | Streaming local Dictate: admit Whisper in `DictateStreamingSession.makeIfEligible` so Offline Mode transcribes chunks while recording, with the existing merged-WAV fallback. **Do not add a Parakeet-class model in this row.** See `plans/active/streaming-dictate.md` slice 4. | A ≥20 s Offline Whisper dictation logs `SPEED: STREAMING-DICTATE: Transcript ready` and stop-to-clipboard is closer to last-chunk time than to full-file Whisper; a failed in-flight chunk still pastes via the merged-WAV fallback. Falsified if WhisperKit hangs/OOM during recording, or if chunk seams hallucinate after F14's peak gate. | BUILD | BRANCH claude/local-speech-to-text-optimize-0da93d |  |

--- a/scripts/agent-loops-job.sh
+++ b/scripts/agent-loops-job.sh
@@ -136,6 +136,15 @@ Hard constraints (rung 0, report-only — see plans/agent-loops.md):
 - Scheduled report: write in English.
 EOF
 
+# The report above is for the human. This block asks the same run to ALSO leave a
+# machine-readable proposal file for the implementer's groomer, so a finding no longer stops at
+# a ledger row nobody flags. The schema lives in one place, not four:
+# scripts/implementer/proposal-prompt.sh. Appending is best-effort — a loop whose report is
+# written must not fail because the sidecar prompt could not be generated.
+bash "$REPO/scripts/implementer/proposal-prompt.sh" agent-loops >>"$PROMPT_FILE" \
+  || echo "WARN: could not append the implementer-proposal block — this run reports only."
+
+
 echo "Review pass: model=$LOOPS_MODEL effort=$LOOPS_EFFORT budget=\$$LOOPS_BUDGET_USD timeout=${LOOPS_TIMEOUT_SECS}s"
 
 KILLED_MARKER="$(mktemp -t wsloopskill)"

--- a/scripts/growth-review-job.sh
+++ b/scripts/growth-review-job.sh
@@ -161,6 +161,15 @@ Hard constraints (rung 0, report-only — see plans/agent-loops.md):
 - Scheduled report: write in English.
 EOF
 
+# The report above is for the human. This block asks the same run to ALSO leave a
+# machine-readable proposal file for the implementer's groomer, so a finding no longer stops at
+# a ledger row nobody flags. The schema lives in one place, not four:
+# scripts/implementer/proposal-prompt.sh. Appending is best-effort — a loop whose report is
+# written must not fail because the sidecar prompt could not be generated.
+bash "$REPO/scripts/implementer/proposal-prompt.sh" growth-review >>"$PROMPT_FILE" \
+  || echo "WARN: could not append the implementer-proposal block — this run reports only."
+
+
 echo "Review pass: model=$GROWTH_MODEL effort=$GROWTH_EFFORT budget=\$$GROWTH_BUDGET_USD timeout=${GROWTH_TIMEOUT_SECS}s"
 
 # Budget caps what a stuck run costs, not how long it runs — kill it ourselves (macOS has

--- a/scripts/implementer/com.whispershortcut.implementer-tick.plist
+++ b/scripts/implementer/com.whispershortcut.implementer-tick.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Hourly heartbeat for the autonomous implementer. Architecture: plans/agent-loops.md.
+
+  Install (after this branch is on main — see the bootstrap note below):
+      bash scripts/implementer/install-tick.sh
+
+  To stop it without unloading anything, set IMPLEMENTER_TICK_ENABLED=0 (or the master switch
+  IMPLEMENTER_ENABLED=0) in ~/.config/whispershortcut-implementer/env. Both are read at run
+  time — no deploy, no edit, which is what the autonomy ladder requires of a kill switch.
+
+  The command bootstraps from origin/main rather than running the tree's copy. This file is the
+  only part of the machine that is not itself under a branch, so it is the only place the
+  bootstrap can live. Without it the tick runs whatever version of itself the shared checkout
+  happens to be sitting on. Falls back to the working tree when origin/main cannot be read.
+
+  StartInterval rather than StartCalendarInterval: this is a laptop. A calendar entry that
+  fires while the lid is shut is simply lost; an interval resumes on wake, which is the whole
+  reason the tick exists.
+-->
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.whispershortcut.implementer-tick</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/bin/bash</string>
+      <string>-lc</string>
+      <string>cd "$HOME/whisper-shortcut-private/whisper-shortcut" || exit 0
+git fetch -q origin main 2>/dev/null
+T=/tmp/whispershortcut-implementer-tick-main.sh
+if git show origin/main:scripts/implementer/tick.sh &gt;"$T" 2>/dev/null &amp;&amp; [ -s "$T" ]; then
+  IMPLEMENTER_TICK_REEXEC=1 IMPLEMENTER_REPO_ROOT="$HOME/whisper-shortcut-private/whisper-shortcut" exec bash "$T"
+fi
+exec bash scripts/implementer/tick.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>3600</integer>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>/tmp/whispershortcut-implementer-tick.out</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/whispershortcut-implementer-tick.err</string>
+  </dict>
+</plist>

--- a/scripts/implementer/groom-queue.py
+++ b/scripts/implementer/groom-queue.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""The groomer — turns loop proposals into queue rows.
+
+Ported from sabaki.dance's scripts/implementer/groom-queue.ts (design 2026-08-19 §6,
+VETO lane 2026-08-28 §4). Architecture: plans/agent-loops.md.
+
+    python3 scripts/implementer/groom-queue.py --dry-run
+    python3 scripts/implementer/groom-queue.py --from /path/to/proposals.json
+
+This is the piece that decides what may be built without a human, so the one property that
+matters is that it contains NO JUDGEMENT. Every rule below is a lookup or a regex against
+committed state; there is no model in this file and there must never be one. A loop says what
+its proposal IS (`class`); this decides what that class is allowed to do, and only ever trusts
+classes an existing gate can judge:
+
+    instrumentation → must name an OPEN row in plans/instrumentation-gaps.md. Blast radius is
+                      one logged field, and the policy already ranks these above features.
+
+Everything else either gets a veto window (reversible, in scope, falsifier a later run can
+grade) or lands in ASK. Nothing is ever dropped: a proposal the groomer cannot justify becomes
+a row you can flip, not a finding that evaporates.
+
+Input: one JSON file per loop run in $IMPLEMENTER_INCOMING_DIR, each holding an object or a
+list of objects:
+
+    {"source": "model-audit 2026-09-03", "title": "…", "proposal": "…",
+     "falsifier": "…", "class": "model-migration", "paths": ["WhisperShortcut/…"],
+     "gap": 8}
+
+Consumed files are moved to `<incoming>/archive/` — a proposal read twice would file the row
+twice, and a proposal deleted on failure would be lost.
+"""
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from datetime import date, timedelta
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(os.path.dirname(SCRIPT_DIR))
+QUEUE_EDIT = os.path.join(SCRIPT_DIR, "queue-edit.py")
+GAPS_FILE = os.path.join(REPO_ROOT, "plans", "instrumentation-gaps.md")
+DEFAULT_INCOMING = os.path.expanduser("~/.local/state/whispershortcut-implementer/incoming")
+
+MAIL_TO = os.environ.get("AUDIT_MAIL_TO", "mail@magnus-goedde.de")
+
+# Classes an existing deterministic gate can judge — these build with no announcement at all.
+AUTO_CLASSES = ("instrumentation",)
+
+# Classes that build on SILENCE. They have no red→green checker the way an instrumentation row
+# has, but they are reversible, in scope, and carry a falsifier a later loop run can read — so
+# the honest gate is your chance to object, not your obligation to approve.
+#
+# The number is the veto window in days. It is per class because the blast radius differs, not
+# because your attention does: a copy change is a word, a model migration changes what every
+# dictation is sent to.
+VETO_WINDOW_DAYS = {
+    "copy": int(os.environ.get("IMPLEMENTER_VETO_DAYS_COPY", 1)),
+    "ui": int(os.environ.get("IMPLEMENTER_VETO_DAYS_UI", 2)),
+    "bug-fix": int(os.environ.get("IMPLEMENTER_VETO_DAYS_BUGFIX", 2)),
+    "model-migration": int(os.environ.get("IMPLEMENTER_VETO_DAYS_MODEL", 3)),
+}
+VETO_LANE_ENABLED = os.environ.get("IMPLEMENTER_VETO_LANE", "1") == "1"
+
+# Both auto lanes count against this. A VETO row is a build that has not started yet, so a
+# groomer that filed ten of them would have queued ten unattended builds, cap or no cap.
+MAX_INFLIGHT = int(os.environ.get("IMPLEMENTER_MAX_INFLIGHT", 3))
+
+# Same allowlist the runner enforces (IMPLEMENTER_SCOPE=app). Checked here too so a
+# hopeless row is filed as ASK rather than starting a build that dies on the scope gate.
+SCOPE_PREFIXES = ("WhisperShortcut/", "WhisperShortcutTests/", "plans/implementer-")
+
+
+def log(msg):
+    print(f"[groom] {msg}", file=sys.stderr)
+
+
+def queue_edit(*args):
+    return subprocess.run(
+        [sys.executable, QUEUE_EDIT, *args],
+        cwd=REPO_ROOT, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def open_gap_numbers():
+    """Gap rows that are still OPEN. `| # | Gap | Blinds | Status | Notes |` — status is cell 4.
+
+    Positional, and safe to be: a bare pipe inside one of the first four cells would break the
+    table for the human reader too, so the register cannot contain one. Rows whose Notes carry
+    extra pipes (gap #7 does) parse fine — the surplus lands past the status column."""
+    if not os.path.exists(GAPS_FILE):
+        return set()
+    nums = set()
+    for line in open(GAPS_FILE, encoding="utf-8"):
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) >= 4 and cells[0].isdigit() and cells[3].upper() == "OPEN":
+            nums.add(int(cells[0]))
+    return nums
+
+
+def normalise(text):
+    return re.sub(r"[^a-z0-9]+", " ", (text or "").lower()).strip()
+
+
+def decide_lane(proposal, existing, gaps, auto_so_far):
+    """Return (lane, reason). Lookups and regexes only — never a judgement call."""
+    cls = (proposal.get("class") or "").strip()
+    title = proposal.get("title") or proposal.get("proposal") or ""
+
+    if not (proposal.get("falsifier") or "").strip():
+        return "ASK", "no falsifier — a row nothing can grade may not build unattended"
+
+    # Dedupe against what the queue actually stores, which is the proposal line. Comparing the
+    # title against it compares two different fields, and a short title never prefixes a longer
+    # proposal — so the check silently never fired. Both directions, because a loop may shorten
+    # or lengthen its wording between runs; both fields, because either may be the stable one.
+    for candidate in (proposal.get("proposal"), title):
+        key = normalise(candidate)[:60]
+        if not key:
+            continue
+        for row in existing:
+            stored = normalise(row["proposal"])
+            if stored.startswith(key) or key.startswith(stored[:60]):
+                return "SKIP", f"already in the queue as #{row['num']}"
+
+    paths = proposal.get("paths") or []
+    outside = [p for p in paths if not p.startswith(SCOPE_PREFIXES)]
+    if outside:
+        return "ASK", f"touches {outside[0]} — outside IMPLEMENTER_SCOPE=app"
+
+    if cls in AUTO_CLASSES:
+        gap = proposal.get("gap")
+        if not isinstance(gap, int) or gap not in gaps:
+            return "ASK", "instrumentation without an OPEN row in plans/instrumentation-gaps.md"
+        if auto_so_far >= MAX_INFLIGHT:
+            return "ASK", f"in-flight cap reached ({MAX_INFLIGHT})"
+        return "BUILD", f"closes instrumentation gap #{gap} — red→green is checkable"
+
+    if cls in VETO_WINDOW_DAYS:
+        if not VETO_LANE_ENABLED:
+            return "ASK", "VETO lane disabled (IMPLEMENTER_VETO_LANE=0)"
+        if auto_so_far >= MAX_INFLIGHT:
+            return "ASK", f"in-flight cap reached ({MAX_INFLIGHT})"
+        days = VETO_WINDOW_DAYS[cls]
+        return "VETO", f"reversible, in scope, falsifier gradeable — builds in {days}d unless stopped"
+
+    return "ASK", f"class '{cls or '(none)'}' has no automatic gate"
+
+
+def load_proposals(paths):
+    out = []
+    for path in paths:
+        try:
+            data = json.load(open(path, encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            log(f"WARN: unreadable proposal file {path}: {exc}")
+            continue
+        for item in (data if isinstance(data, list) else [data]):
+            if isinstance(item, dict):
+                out.append((path, item))
+    return out
+
+
+def send_mail(subject, body, no_mail=False):
+    if no_mail:
+        log("--no-mail: NOT sending the announcement below. This is a test run only.")
+        log(f"  subject: {subject}")
+        for line in body.splitlines():
+            log(f"  | {line}")
+        return
+    helper = os.path.join(REPO_ROOT, "scripts", "send-report-mail.py")
+    tmp = os.path.join("/tmp", f"groom-announce-{os.getpid()}.md")
+    with open(tmp, "w", encoding="utf-8") as fh:
+        fh.write(body)
+    try:
+        rc = subprocess.run(
+            [sys.executable, helper, "--to", MAIL_TO, "--subject", subject, "--body-file", tmp]
+        ).returncode
+        if rc != 0:
+            # A VETO row that is never announced is not a veto window — it is an unattended
+            # build the operator was never told about. Say so loudly rather than proceeding
+            # quietly; the notification is the fallback channel the other jobs already use.
+            log("WARN: could not mail the VETO announcement — falling back to a notification")
+            subprocess.run(
+                ["osascript", "-e",
+                 f'display notification "{len(body.splitlines())} lines — see the queue" '
+                 f'with title "{subject}"'],
+                capture_output=True,
+            )
+    finally:
+        os.unlink(tmp)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--from", dest="src", action="append", default=[])
+    # Testing only. A VETO row that is not announced is not a veto window — it is an unattended
+    # build nobody was told about — so this prints the announcement instead of suppressing it,
+    # and says so. Never use it from tick.sh.
+    ap.add_argument("--no-mail", action="store_true",
+                    help="print announcements instead of mailing them (testing)")
+    args = ap.parse_args()
+
+    incoming = os.environ.get("IMPLEMENTER_INCOMING_DIR", DEFAULT_INCOMING)
+    files = list(args.src)
+    if not files and os.path.isdir(incoming):
+        files = sorted(
+            os.path.join(incoming, f) for f in os.listdir(incoming) if f.endswith(".json")
+        )
+
+    existing = json.loads(queue_edit("list"))
+    open_auto = [r for r in existing if r["flag"] in ("BUILD", "VETO") and r["status"] == "OPEN"]
+    auto_so_far = len(open_auto)
+
+    # A VETO row whose deadline is missing or unreadable promotes never and was announced
+    # never — it just sits there looking queued. `due` cannot see it, so nothing else would
+    # ever mention it again. Say so every tick.
+    for row in open_auto:
+        if row["flag"] == "VETO" and not re.match(r"^\d{4}-\d{2}-\d{2}", row["deadline"]):
+            log(f"WARN: row #{row['num']} is VETO with no readable deadline "
+                f"({row['deadline']!r}) — it will never build. Give it one or flag it ASK.")
+
+    gaps = open_gap_numbers()
+    proposals = load_proposals(files)
+    log(f"{len(proposals)} proposal(s) from {len(files)} file(s) · {auto_so_far} already in flight")
+
+    announcements, filed = [], []
+    for path, proposal in proposals:
+        lane, reason = decide_lane(proposal, existing, gaps, auto_so_far)
+        title = proposal.get("title") or proposal.get("proposal") or "(no title)"
+        icon = {"BUILD": "🟢", "VETO": "🔵", "ASK": "🟡", "SKIP": "⚪️"}[lane]
+        log(f"{icon} {lane}: {title[:70]} — {reason}")
+        if lane == "SKIP" or args.dry_run:
+            continue
+
+        deadline = ""
+        if lane == "VETO":
+            days = VETO_WINDOW_DAYS[proposal["class"]]
+            deadline = (date.today() + timedelta(days=days)).isoformat()
+
+        num = queue_edit(
+            "append",
+            "--source", proposal.get("source", "loop proposal"),
+            "--proposal", proposal.get("proposal") or title,
+            "--falsifier", proposal.get("falsifier", ""),
+            "--flag", lane,
+            "--deadline", deadline,
+        )
+        filed.append((num, lane, title))
+        # Re-read so the next proposal's duplicate check sees the row we just wrote.
+        existing = json.loads(queue_edit("list"))
+        if lane in ("BUILD", "VETO"):
+            auto_so_far += 1
+        if lane == "VETO":
+            announcements.append((num, title, deadline, reason))
+
+    # Silence promotes. A row whose window ran out becomes BUILD; a row you stopped is ASK by
+    # now and `due` never sees it again.
+    ripe = json.loads(queue_edit("due")) if not args.dry_run else []
+    for row in ripe:
+        queue_edit("set-flag", str(row["num"]), "BUILD")
+        log(f"🟢 promoted #{row['num']} — veto window ended {row['deadline']}")
+
+    if not args.dry_run:
+        archive = os.path.join(incoming, "archive")
+        os.makedirs(archive, exist_ok=True)
+        for path in {p for p, _ in proposals}:
+            if os.path.dirname(path) == incoming:
+                shutil.move(path, os.path.join(archive, os.path.basename(path)))
+
+    if announcements or ripe:
+        lines = []
+        if announcements:
+            lines += [
+                "The implementer filed these in the VETO lane. You do not have to do anything —",
+                "they build on their deadline unless you stop them:",
+                "",
+                *[f"#{n} — {t}\n    builds on {d} unless stopped · {r}" for n, t, d, r in announcements],
+                "",
+                "Stop one with:  bash scripts/implementer/veto.sh <#>",
+                "",
+            ]
+        if ripe:
+            lines += [
+                "Promoted to BUILD — their veto window ran out:",
+                *[f"#{r['num']} — {r['title']} (window ended {r['deadline']})" for r in ripe],
+                "",
+            ]
+        lines.append("Queue: plans/implementer-queue.md")
+        send_mail(
+            f"WhisperShortcut implementer — {len(announcements)} to veto, {len(ripe)} promoted",
+            "\n".join(lines),
+            no_mail=args.no_mail,
+        )
+
+    # Commit on main: a proposal filed on a branch nobody merges is a proposal nobody sees.
+    #
+    # The pathspec form is not a style choice. `git add <file>` followed by a bare `git commit`
+    # commits everything ALREADY STAGED — so a tick firing while the operator had staged work
+    # in the shared checkout would sweep that work into a commit titled "Groom implementer
+    # queue". Naming the path makes the commit contain exactly this file, whatever the index
+    # holds.
+    if (filed or ripe) and not args.dry_run:
+        subprocess.run(
+            ["git", "commit", "-m",
+             f"Groom implementer queue: {len(filed)} filed, {len(ripe)} promoted\n\n"
+             "Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>",
+             "--", "plans/implementer-queue.md"],
+            cwd=REPO_ROOT, capture_output=True, check=False,
+        )
+    log(f"done — {len(filed)} filed, {len(ripe)} promoted")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/implementer/install-implementer.sh
+++ b/scripts/implementer/install-implementer.sh
@@ -44,7 +44,30 @@ IMPLEMENTER_PUSH_PR=1
 # Only after 5 consecutive clean MERGED rows in plans/implementer-log.md, and only
 # by your hand — it lets the runner pick a proposal when the queue has no BUILD row.
 # IMPLEMENTER_SELF_PICK=1
+
+# --- Schedule (tick.sh, installed with scripts/implementer/install-tick.sh) -------------
+# Second switch on purpose: IMPLEMENTER_ENABLED is the master kill switch every implementer
+# script shares, this one stops only the hourly schedule. Read at run time, so turning the
+# automation off never needs an edit or a rebuild.
+IMPLEMENTER_TICK_ENABLED=0
+IMPLEMENTER_GROOM=1                # file loop proposals into the queue on every tick
+
+# --- The VETO lane ----------------------------------------------------------------------
+# Rows the groomer can justify but no gate can judge are announced by mail with a deadline and
+# promoted to BUILD on silence. Adding this lane LOOSENED a gate, which plans/agent-loops.md
+# reserves for a human — decided 2026-09-03. Set to 0 and everything the groomer cannot prove
+# lands in ASK instead, which is the pre-2026-09-03 behaviour.
+IMPLEMENTER_VETO_LANE=1
+IMPLEMENTER_VETO_DAYS_COPY=1       # windows are per class because blast radius differs,
+IMPLEMENTER_VETO_DAYS_UI=2         # not because your attention does
+IMPLEMENTER_VETO_DAYS_BUGFIX=2
+IMPLEMENTER_VETO_DAYS_MODEL=3
+IMPLEMENTER_MAX_INFLIGHT=3         # BUILD+VETO rows still OPEN; a VETO row is a queued build
+
+# Where the loop jobs drop their proposal JSON for the groomer.
+# IMPLEMENTER_INCOMING_DIR=~/.local/state/whispershortcut-implementer/incoming
 EOF
 chmod 600 "$CONFIG_FILE"
 echo "Created ${CONFIG_FILE}"
 echo "Review it, then set IMPLEMENTER_ENABLED=1 to arm the runner."
+echo "For the hourly lane: bash scripts/implementer/install-tick.sh, then IMPLEMENTER_TICK_ENABLED=1."

--- a/scripts/implementer/install-tick.sh
+++ b/scripts/implementer/install-tick.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Put the hourly implementer tick under launchd. Idempotent — re-running reloads it.
+#
+#     bash scripts/implementer/install-tick.sh          # install / reload
+#     bash scripts/implementer/install-tick.sh --remove # unload and delete
+#
+# The tick itself does nothing until BOTH switches in ~/.config/whispershortcut-implementer/env
+# are 1 (IMPLEMENTER_ENABLED, IMPLEMENTER_TICK_ENABLED), so installing this is safe and
+# reversible on its own. Architecture: plans/agent-loops.md.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LABEL="com.whispershortcut.implementer-tick"
+SRC="${SCRIPT_DIR}/${LABEL}.plist"
+DEST="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+
+if [[ "${1:-}" == "--remove" ]]; then
+    launchctl unload "$DEST" 2>/dev/null || true
+    rm -f "$DEST"
+    echo "Removed ${DEST}"
+    exit 0
+fi
+
+# The plist's bootstrap runs `git show origin/main:scripts/implementer/tick.sh`. Installing it
+# while that file is not on main yet means every hour falls through to the working tree — which
+# is whatever branch the shared checkout is sitting on. Refuse rather than schedule that.
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+if ! git -C "$REPO_ROOT" cat-file -e origin/main:scripts/implementer/tick.sh 2>/dev/null; then
+    echo "REFUSING: scripts/implementer/tick.sh is not on origin/main yet." >&2
+    echo "Merge the branch first — the plist bootstraps from main by design." >&2
+    exit 1
+fi
+
+mkdir -p "${HOME}/Library/LaunchAgents"
+launchctl unload "$DEST" 2>/dev/null || true
+cp "$SRC" "$DEST"
+launchctl load "$DEST"
+echo "Installed and loaded ${DEST} (hourly)."
+echo
+echo "It stays inert until you arm it in ~/.config/whispershortcut-implementer/env:"
+echo "    IMPLEMENTER_ENABLED=1"
+echo "    IMPLEMENTER_TICK_ENABLED=1"
+echo
+echo "Logs: build/logs/implementer/tick-\$(date +%F).log  ·  /tmp/${LABEL}.{out,err}"

--- a/scripts/implementer/proposal-prompt.sh
+++ b/scripts/implementer/proposal-prompt.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Prints the block every loop job appends to its Claude prompt, telling it to drop a machine-
+# readable proposal file next to its prose report.
+#
+#     bash scripts/implementer/proposal-prompt.sh <loop-name> >> "$PROMPT_FILE"
+#
+# Why a sidecar rather than parsing the reports: the groomer must contain no judgement
+# (scripts/implementer/groom-queue.py), and a parser guessing which paragraph of a monthly audit
+# is a proposal is exactly that. The loop already knows what it is proposing — it just has to
+# say so in a form a lookup table can read. One place to maintain the schema; four callers.
+set -euo pipefail
+LOOP="${1:?usage: proposal-prompt.sh <loop-name>}"
+INCOMING="${IMPLEMENTER_INCOMING_DIR:-$HOME/.local/state/whispershortcut-implementer/incoming}"
+mkdir -p "$INCOMING"
+
+cat <<EOF
+
+## Also: hand your proposals to the implementer
+
+Besides the report above, write a JSON file to:
+
+    ${INCOMING}/${LOOP}-$(date +%Y-%m-%d-%H%M%S).json
+
+It holds a LIST of the proposals from this run that are concrete enough to build — usually 0 to
+3, and **an empty list \`[]\` is the right answer whenever this run's honest verdict is "build
+nothing"**. Do not invent a proposal to fill the file. Each object:
+
+    {
+      "source":    "${LOOP} $(date +%Y-%m-%d) — <which ledger row / section this came from>",
+      "title":     "<max 80 chars, distinct enough that the same finding next month matches it>",
+      "proposal":  "<ONE line, imperative, naming the files to change. This becomes the queue row a build agent works from.>",
+      "falsifier": "<what measurement, on what date, would show this did NOT work. Name the exact query or log line. No falsifier means the row cannot build unattended.>",
+      "class":     "instrumentation | bug-fix | model-migration | ui | copy | other",
+      "paths":     ["WhisperShortcut/…"],
+      "gap":       <instrumentation only: the OPEN row number in plans/instrumentation-gaps.md this closes>
+    }
+
+Pick \`class\` by what the change IS, never by how badly you want it built — it decides which
+gate the proposal has to pass, and a mislabelled row is the one way this pipeline can build
+something nobody agreed to:
+
+- \`instrumentation\` — adds or repairs a logged field. Must set \`gap\` to an OPEN row in
+  plans/instrumentation-gaps.md. Builds immediately; the gap row is the checker.
+- \`bug-fix\` — a defect with a repro. \`model-migration\` — a model ID swap the audit justified.
+  \`ui\`, \`copy\` — user-visible surface. These get a veto window: announced by mail, built on
+  silence, stopped with \`bash scripts/implementer/veto.sh <#>\`.
+- \`other\` (or anything you are unsure about) — filed for a human decision. Use it freely;
+  nothing is lost, and a wrong \`class\` costs more than a cautious one.
+
+Constraints that are checked, not trusted: \`paths\` must all start with \`WhisperShortcut/\`,
+\`WhisperShortcutTests/\` or \`plans/implementer-\`; anything else is filed for a human instead.
+Do not set a flag, a deadline or a queue number — the groomer assigns those, and it is the only
+thing here allowed to.
+EOF

--- a/scripts/implementer/queue-edit.py
+++ b/scripts/implementer/queue-edit.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""The one place that parses and writes plans/implementer-queue.md.
+
+Every other script goes through this. The queue is a markdown table that a human reads and
+edits by hand, so it is also the single most fragile interface in the machinery: two
+independent parsers would drift, and the first symptom would be a row silently skipped.
+
+Ported from sabaki.dance's scripts/implementer/queue-edit.ts. Python rather than TypeScript
+because this repo is Swift + bash and has no node toolchain; adding one for a table parser
+would be a dependency nobody maintains.
+
+    queue-edit.py list                       → JSON of every row
+    queue-edit.py append --source S --proposal P --falsifier F --flag VETO --deadline D
+    queue-edit.py set-flag 7 BUILD
+    queue-edit.py set-status 7 'BRANCH implementer/q7-20260903'
+    queue-edit.py due                        → JSON of VETO rows whose deadline has passed
+    queue-edit.py veto 7                     → VETO row back to ASK (the operator's stop button)
+
+Exit codes: 0 done, 1 nothing matched / bad input.
+"""
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import date, timedelta
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+QUEUE_FILE = os.path.join(REPO_ROOT, "plans", "implementer-queue.md")
+
+FLAGS = ("HOLD", "ASK", "VETO", "BUILD")
+COLUMNS = ("num", "source", "proposal", "falsifier", "flag", "status", "deadline")
+ROW_RE = re.compile(r"^\|\s*(\d+)\s*\|")
+
+
+def cell(text):
+    """A table cell may never contain a bare pipe — it would create a phantom column and the
+    runner's awk would read the wrong field. Escape rather than reject: the proposal text comes
+    from a loop's report and rejecting it there would lose the finding."""
+    return re.sub(r"\s+", " ", str(text).replace("|", "\\|")).strip()
+
+
+def split_row(line):
+    """Split a markdown row into cells, honouring \\| escapes."""
+    body = line.strip()
+    body = body[1:] if body.startswith("|") else body
+    body = body[:-1] if body.endswith("|") else body
+    parts = re.split(r"(?<!\\)\|", body)
+    return [p.replace("\\|", "|").strip() for p in parts]
+
+
+def read_queue():
+    with open(QUEUE_FILE, encoding="utf-8") as fh:
+        return fh.read().split("\n")
+
+
+def parse_rows(lines):
+    rows = []
+    for idx, line in enumerate(lines):
+        if not ROW_RE.match(line):
+            continue
+        cells = split_row(line)
+        row = {k: (cells[i] if i < len(cells) else "") for i, k in enumerate(COLUMNS)}
+        row["num"] = int(row["num"])
+        row["_line"] = idx
+        rows.append(row)
+    return rows
+
+
+def write_queue(lines):
+    with open(QUEUE_FILE, "w", encoding="utf-8") as fh:
+        fh.write("\n".join(lines))
+
+
+def render(row):
+    return "| " + " | ".join(cell(row.get(k, "")) for k in COLUMNS) + " |"
+
+
+def cmd_list(_args):
+    rows = parse_rows(read_queue())
+    for r in rows:
+        r.pop("_line", None)
+    print(json.dumps(rows, ensure_ascii=False, indent=2))
+    return 0
+
+
+def cmd_append(args):
+    if args.flag not in FLAGS:
+        print(f"unknown flag '{args.flag}' (one of {', '.join(FLAGS)})", file=sys.stderr)
+        return 1
+    lines = read_queue()
+    rows = parse_rows(lines)
+    if not rows:
+        print("queue has no rows to append after — is the table intact?", file=sys.stderr)
+        return 1
+    num = max(r["num"] for r in rows) + 1
+    new = {
+        "num": num,
+        "source": args.source,
+        "proposal": args.proposal,
+        "falsifier": args.falsifier,
+        "flag": args.flag,
+        "status": "OPEN",
+        "deadline": args.deadline or "",
+    }
+    lines.insert(rows[-1]["_line"] + 1, render(new))
+    write_queue(lines)
+    print(num)
+    return 0
+
+
+def _update(num, field, value):
+    lines = read_queue()
+    for row in parse_rows(lines):
+        if row["num"] != num:
+            continue
+        row[field] = value
+        lines[row["_line"]] = render(row)
+        write_queue(lines)
+        return 0
+    print(f"no row #{num} in the queue", file=sys.stderr)
+    return 1
+
+
+def cmd_set_flag(args):
+    if args.flag not in FLAGS:
+        print(f"unknown flag '{args.flag}'", file=sys.stderr)
+        return 1
+    # A VETO row without a deadline is the worst state in the table: `due` skips it, so it never
+    # promotes, and it was never announced either — a proposal that silently stops existing
+    # while still looking queued. Refuse rather than create one.
+    if args.flag == "VETO" and not re.match(r"^\d{4}-\d{2}-\d{2}", args.deadline or ""):
+        print("VETO needs --deadline YYYY-MM-DD — a row without one never builds and was "
+              "never announced", file=sys.stderr)
+        return 1
+    # A row leaving the VETO lane has no deadline any more; leaving a stale one behind would
+    # make `due` re-promote a row the operator already stopped.
+    rc = _update(args.num, "flag", args.flag)
+    if rc == 0:
+        _update(args.num, "deadline", args.deadline if args.flag == "VETO" else "")
+    return rc
+
+
+def cmd_set_status(args):
+    return _update(args.num, "status", args.status)
+
+
+def cmd_due(_args):
+    """VETO rows whose window ran out. Compared as ISO strings deliberately: a deadline the
+    operator extended by hand ("2026-09-10 (verlängert)") must still parse, and a lexical
+    compare on the leading YYYY-MM-DD does that without a date library guessing at the rest."""
+    today = date.today().isoformat()
+    ripe = []
+    for row in parse_rows(read_queue()):
+        if row["flag"] != "VETO" or row["status"] != "OPEN":
+            continue
+        stamp = row["deadline"][:10]
+        if re.fullmatch(r"\d{4}-\d{2}-\d{2}", stamp) and stamp <= today:
+            ripe.append({"num": row["num"], "title": row["proposal"][:80], "deadline": row["deadline"]})
+    print(json.dumps(ripe, ensure_ascii=False))
+    return 0
+
+
+def cmd_veto(args):
+    """The operator's stop button. VETO → ASK, so the row survives as a decision to make
+    rather than vanishing — a stopped proposal is still a finding somebody had."""
+    lines = read_queue()
+    for row in parse_rows(lines):
+        if row["num"] != args.num:
+            continue
+        if row["flag"] != "VETO":
+            print(f"row #{args.num} is {row['flag']}, not VETO — nothing to stop", file=sys.stderr)
+            return 1
+        row["flag"], row["deadline"] = "ASK", ""
+        lines[row["_line"]] = render(row)
+        write_queue(lines)
+        print(f"row #{args.num} stopped — now ASK, it will not build unattended")
+        return 0
+    print(f"no row #{args.num} in the queue", file=sys.stderr)
+    return 1
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("list").set_defaults(fn=cmd_list)
+    sub.add_parser("due").set_defaults(fn=cmd_due)
+
+    ap_a = sub.add_parser("append")
+    ap_a.add_argument("--source", required=True)
+    ap_a.add_argument("--proposal", required=True)
+    ap_a.add_argument("--falsifier", required=True)
+    ap_a.add_argument("--flag", required=True)
+    ap_a.add_argument("--deadline", default="")
+    ap_a.set_defaults(fn=cmd_append)
+
+    ap_f = sub.add_parser("set-flag")
+    ap_f.add_argument("num", type=int)
+    ap_f.add_argument("flag")
+    ap_f.add_argument("--deadline", default="", help="required when setting VETO")
+    ap_f.set_defaults(fn=cmd_set_flag)
+
+    ap_s = sub.add_parser("set-status")
+    ap_s.add_argument("num", type=int)
+    ap_s.add_argument("status")
+    ap_s.set_defaults(fn=cmd_set_status)
+
+    ap_v = sub.add_parser("veto")
+    ap_v.add_argument("num", type=int)
+    ap_v.set_defaults(fn=cmd_veto)
+
+    args = ap.parse_args()
+    sys.exit(args.fn(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/implementer/tick.sh
+++ b/scripts/implementer/tick.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# The implementer's heartbeat — hourly under launchd.
+#
+# Architecture: plans/agent-loops.md. Ported from sabaki.dance's scripts/implementer/tick.sh,
+# including the three failures that lane paid for and this one does not have to repeat again.
+#
+# Two steps, in this order, each skippable without blocking the next:
+#   1. groom the queue  (groom-queue.py) — file loop proposals, promote ripe VETO rows
+#   2. start the next build (run-implementer.sh) — takes the topmost BUILD/OPEN row
+#
+# The tick never decides anything. Every build it starts was released either by you flagging a
+# row BUILD, or by a veto window running out while you said nothing.
+#
+# Why hourly rather than one nightly run: the pipeline needs a Mac that is awake, and this one
+# is a laptop. An hourly tick turns "the lid was shut" into LATER instead of NEVER.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Survives the re-exec below, where SCRIPT_DIR is /tmp and would compute nonsense.
+REPO_ROOT="${IMPLEMENTER_REPO_ROOT:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"
+[[ -n "${IMPLEMENTER_REPO_ROOT:-}" ]] && SCRIPT_DIR="${REPO_ROOT}/scripts/implementer"
+
+# --- Run the version of ourselves that is on main --------------------------------------------
+# launchd starts a path in the SHARED checkout, whose content is whatever branch somebody left
+# it on. Sabaki spent 2026-08-28 running a months-old copy of this file while the fix for
+# exactly that sat on main, unreachable — a loop that cannot rely on running its own current
+# code cannot be trusted to improve itself. So pin to origin/main and re-exec when they differ.
+if [[ -z "${IMPLEMENTER_TICK_REEXEC:-}" ]]; then
+    PINNED="/tmp/whispershortcut-implementer-tick-main.sh"
+    git -C "$REPO_ROOT" fetch -q origin main 2>/dev/null || true
+    if git -C "$REPO_ROOT" show origin/main:scripts/implementer/tick.sh >"$PINNED" 2>/dev/null \
+        && [[ -s "$PINNED" ]] && ! cmp -s "$PINNED" "${BASH_SOURCE[0]}" \
+        && grep -q 'IMPLEMENTER_REPO_ROOT' "$PINNED"; then
+        export IMPLEMENTER_TICK_REEXEC=1 IMPLEMENTER_REPO_ROOT="$REPO_ROOT"
+        exec bash "$PINNED"
+    fi
+    rm -f "$PINNED"
+fi
+
+TICK_LOG_DIR="${REPO_ROOT}/build/logs/implementer"
+mkdir -p "$TICK_LOG_DIR"
+exec > >(tee -a "${TICK_LOG_DIR}/tick-$(date +%F).log") 2>&1
+
+log()  { printf '[tick %s] %s\n' "$(date +%H:%M)" "$*"; }
+warn() { printf '[tick %s] WARN: %s\n' "$(date +%H:%M)" "$*"; }
+
+# --- PATH ------------------------------------------------------------------------------------
+# launchd's `bash -lc` reads ~/.bash_profile, which does not exist here — the PATH additions
+# live in ~/.zshrc and bash never sees them. So under launchd there is no ~/.local/bin, which
+# is where cursor-agent AND claude live: the build agent and the review agent both. Sabaki's
+# scheduled lane died on "cursor-agent not found" 87 times in a row while the binary sat
+# installed and current the whole time. Prepend, so a stale copy on the system path cannot
+# shadow the one actually maintained.
+for extra in "${HOME}/.local/bin" /opt/homebrew/bin /usr/local/bin; do
+    [[ -d "$extra" ]] && case ":${PATH}:" in *":${extra}:"*) ;; *) export PATH="${extra}:${PATH}" ;; esac
+done
+
+CONFIG_FILE="${HOME}/.config/whispershortcut-implementer/env"
+if [[ -f "$CONFIG_FILE" ]]; then
+    set -a; # shellcheck disable=SC1090
+    source "$CONFIG_FILE"; set +a
+fi
+
+# Two switches on purpose: IMPLEMENTER_ENABLED is the master kill switch shared with every
+# other implementer script, IMPLEMENTER_TICK_ENABLED stops only the schedule. Both are read at
+# run time — turning the automation off must never require an edit or a rebuild.
+[[ "${IMPLEMENTER_ENABLED:-0}" == "1" ]]      || { log "IMPLEMENTER_ENABLED is not 1 — nothing to do."; exit 0; }
+[[ "${IMPLEMENTER_TICK_ENABLED:-0}" == "1" ]] || { log "IMPLEMENTER_TICK_ENABLED is not 1 — schedule is off."; exit 0; }
+
+# The runner refuses without these, but it refuses one at a time and only once a build starts.
+# Name every missing one here, every hour: a lane that cannot build must not look idle.
+for tool in cursor-agent claude gh; do
+    command -v "$tool" >/dev/null 2>&1 || warn "${tool} is not on PATH — the build lane cannot complete until it is"
+done
+
+log "tick start (repo ${REPO_ROOT})"
+
+# --- Is the shared checkout usable? ----------------------------------------------------------
+# Both steps write in the main checkout, so both need it on main and clean. This guard used to
+# be Sabaki's worst blocker: it sat at the top and killed the whole tick, so 28 proposals piled
+# up unread for eight days while the queue kept showing the same three hand-written rows. The
+# fix there was per-step guards; the fix here is the same guard plus LOUD reporting, because a
+# blocked lane that only whispers into a log file is indistinguishable from a quiet week.
+BLOCK_STAMP="${TICK_LOG_DIR}/.blocked-since"
+CURRENT_BRANCH=$(git -C "$REPO_ROOT" symbolic-ref --short HEAD 2>/dev/null || echo '(detached)')
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+    warn "main checkout is on '${CURRENT_BRANCH}' — the tick cannot groom or build until it is back on main."
+    [[ -f "$BLOCK_STAMP" ]] || date +%s >"$BLOCK_STAMP"
+    BLOCKED_HOURS=$(( ($(date +%s) - $(cat "$BLOCK_STAMP")) / 3600 ))
+    # Report once a day, not once an hour — an alert that fires 24 times becomes noise, and
+    # noise is how the eight-day blockage stayed invisible in the first place.
+    #
+    # Against a threshold, not `% 24 == 0`: this is a laptop, so ticks are skipped whenever the
+    # lid is shut. A modulo test needs to land on the exact hour and would jump 23 → 25 over a
+    # closed night — silently never reporting, which is the failure this whole block exists to
+    # prevent. The last reported milestone is remembered instead.
+    REPORTED_FILE="${BLOCK_STAMP}.reported"
+    LAST_REPORTED=$(cat "$REPORTED_FILE" 2>/dev/null || echo 0)
+    if (( BLOCKED_HOURS >= LAST_REPORTED + 24 )); then
+        echo "$BLOCKED_HOURS" >"$REPORTED_FILE"
+        NOTE=$(mktemp -t wstickblocked)
+        {
+            echo "VERDICT: implementer tick BLOCKED for ${BLOCKED_HOURS}h — checkout is on '${CURRENT_BRANCH}'."
+            echo
+            echo "Nothing has been groomed or built since then. Loop proposals are accumulating in"
+            echo "\${IMPLEMENTER_INCOMING_DIR:-~/.local/state/whispershortcut-implementer/incoming}."
+            echo "Fix: git -C ${REPO_ROOT} checkout main"
+        } >"$NOTE"
+        python3 "${REPO_ROOT}/scripts/send-report-mail.py" --to "${AUDIT_MAIL_TO:-mail@magnus-goedde.de}" \
+            --subject "WhisperShortcut implementer tick BLOCKED (${BLOCKED_HOURS}h)" --body-file "$NOTE" \
+            || osascript -e "display notification \"on branch ${CURRENT_BRANCH} for ${BLOCKED_HOURS}h\" with title \"Implementer tick blocked\"" >/dev/null 2>&1
+        rm -f "$NOTE"
+    fi
+    exit 0
+fi
+rm -f "$BLOCK_STAMP" "${BLOCK_STAMP}.reported"
+
+# --- 1. Groom --------------------------------------------------------------------------------
+if [[ "${IMPLEMENTER_GROOM:-1}" == "1" ]]; then
+    log "step 1: grooming the queue"
+    python3 "${SCRIPT_DIR}/groom-queue.py" || warn "groom-queue.py exited non-zero — see above"
+else
+    log "step 1: skipped (IMPLEMENTER_GROOM=0)"
+fi
+
+# --- 2. Build --------------------------------------------------------------------------------
+# The runner does its own preflight (lock, monthly budget, scope, clean tree) and exits 0 with
+# "nothing to do" when no BUILD/OPEN row exists, which is the common case. Let it decide.
+log "step 2: starting the next build if one is due"
+bash "${SCRIPT_DIR}/run-implementer.sh" || warn "run-implementer.sh exited non-zero — see above"
+
+log "tick done"

--- a/scripts/implementer/veto.sh
+++ b/scripts/implementer/veto.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Stop a VETO row before its window runs out — the operator's only obligation in that lane.
+#
+#     bash scripts/implementer/veto.sh 7
+#
+# The row becomes ASK: it does not build unattended any more, but it stays in the queue as a
+# decision to make. A stopped proposal is still a finding somebody had.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[[ $# -eq 1 ]] || { echo "usage: veto.sh <queue-row-number>" >&2; exit 2; }
+exec python3 "${SCRIPT_DIR}/queue-edit.py" veto "$1"

--- a/scripts/model-audit-job.sh
+++ b/scripts/model-audit-job.sh
@@ -171,6 +171,15 @@ Hard constraints:
   leaks hallucinated transcripts), the measurement wins — say so.
 EOF
 
+# The report above is for the human. This block asks the same run to ALSO leave a
+# machine-readable proposal file for the implementer's groomer, so a finding no longer stops at
+# a ledger row nobody flags. The schema lives in one place, not four:
+# scripts/implementer/proposal-prompt.sh. Appending is best-effort — a loop whose report is
+# written must not fail because the sidecar prompt could not be generated.
+bash "$REPO/scripts/implementer/proposal-prompt.sh" model-audit >>"$PROMPT_FILE" \
+  || echo "WARN: could not append the implementer-proposal block — this run reports only."
+
+
 # A launchd job nobody is watching must say something when it finishes — and especially when it
 # fails. Silence is indistinguishable from "never ran".
 #

--- a/scripts/usage-review-job.sh
+++ b/scripts/usage-review-job.sh
@@ -314,6 +314,15 @@ is read once a week by one person deciding whether to act.
   A quiet week reported honestly is a good outcome, and padding it is how the ledger dies.
 EOF
 
+# The report above is for the human. This block asks the same run to ALSO leave a
+# machine-readable proposal file for the implementer's groomer, so a finding no longer stops at
+# a ledger row nobody flags. The schema lives in one place, not four:
+# scripts/implementer/proposal-prompt.sh. Appending is best-effort — a loop whose report is
+# written must not fail because the sidecar prompt could not be generated.
+bash "$REPO/scripts/implementer/proposal-prompt.sh" usage-review >>"$PROMPT_FILE" \
+  || echo "WARN: could not append the implementer-proposal block — this run reports only."
+
+
 echo "Review pass: model=$REVIEW_MODEL effort=$REVIEW_EFFORT budget=\$$REVIEW_BUDGET_USD"
 
 # The budget cap bounds what a stuck run COSTS, but not how long it runs — the 2026-08-17 run sat


### PR DESCRIPTION
The monthly model audit found `gemini-3.8-flash` on 2026-09-03 and nothing built it. Three independent reasons, each sufficient on its own:

1. **No path from a finding to a queue row.** The four loop jobs are rung 0 and write prose reports nobody reads back. There was no groomer.
2. **No lane a loop could release into.** `BUILD` was reserved for a human act, so every proposal waited for approval that often never came — queue row 2 has sat `OPEN` since 2026-08-20.
3. **No schedule.** The runner's cadence was literally "on demand": a `BUILD` row waited for someone to type the command.

This closes all three, porting sabaki.dance's shape.

## What is added

| File | Role |
| --- | --- |
| `scripts/implementer/tick.sh` | Hourly under launchd: groom, then build one released row. Two kill switches read at run time, launchd PATH fix, loud reporting when the shared checkout is blocked |
| `scripts/implementer/groom-queue.py` | Turns loop proposals into rows. **Contains no model, by construction** — every lane is a lookup or a regex against committed state |
| `scripts/implementer/queue-edit.py` | The one place that parses and writes the queue table |
| `scripts/implementer/veto.sh` | The stop button: `veto.sh 7` moves a row to `ASK` |
| `scripts/implementer/proposal-prompt.sh` | The proposal JSON schema, in one place instead of four |
| `com.whispershortcut.implementer-tick.plist` + `install-tick.sh` | `StartInterval`, not a calendar entry — on a laptop a calendar fire during a closed lid is lost, an interval resumes on wake |

The four loop jobs now also drop a `proposals.json` sidecar. Parsing their prose would have put judgement back into the groomer, which is the one thing it may not have.

## The VETO lane loosens a gate — deliberately, and by a human decision

`plans/agent-loops.md` says an agent may tighten a gate, never loosen one. This lane was **asked and answered by the owner on 2026-09-03**, lands in its own commit, and sits behind `IMPLEMENTER_VETO_LANE=0`.

What it changes is **who must act**: before, a proposal nothing could prove waited for approval; now it waits for an objection. What it does **not** change is any gate on the code — the runner still re-runs the scope allowlist, clean tree, pollution check, `xcodebuild` and the full test plan, a different model still reviews the diff, and the output is still a PR you merge.

**The hourly tick does not mean hourly builds.** A tick with no released row exits in under a second. What bounds spend is unchanged: 10 runs/month (`IMPLEMENTER_MAX_RUNS_PER_MONTH`) and at most 3 auto rows in flight (`IMPLEMENTER_MAX_INFLIGHT`).

## Verification

Run against the real repo state — all five lanes decide correctly:

```
🔵 VETO: Add gemini-3.8-flash, prune 3.5/3.6-flash — builds in 3d unless stopped
🟢 BUILD: Read Apple churn in every growth run — closes instrumentation gap #6
🟡 ASK:  No falsifier on purpose — a row nothing can grade may not build unattended
🟡 ASK:  Retag the site CTAs — touches web/app/page.tsx, outside IMPLEMENTER_SCOPE=app
⚪️ SKIP: (the same migration restated a month later) — already in the queue as #4
```

Also verified: a ripe veto window promotes to `BUILD`; `veto.sh` moves a row to `ASK` and clears its deadline; the runner's existing awk reads the widened table unchanged (`Deadline` was appended as the last column, so fields `$6`/`$7` are untouched); `** BUILD SUCCEEDED **`.

**Three defects found in self-review and fixed:**
1. The dedupe compared the incoming *title* against the stored *proposal* — two different fields, so a short title never prefixed a longer proposal and the check silently never fired. The same audit finding would have re-entered the queue every month.
2. The groomer's `git add` + bare `git commit` commits everything already staged — a tick firing while you had staged work would have swept it into a commit titled "Groom implementer queue". Now uses the pathspec form; verified with staged work present.
3. The blocked-lane alert used `% 24 == 0`. On a laptop ticks are skipped, the counter steps 23 → 25 and never reports — exactly the failure the block exists to prevent. Now a threshold against a remembered milestone.

One gap surfaced by testing and closed: a `VETO` row with no deadline promotes never and was announced never — it just sits there looking queued. `set-flag VETO` now requires a deadline, and the groomer warns about such rows on every tick.

## After merging

The plist bootstraps from `origin/main` by design, so `install-tick.sh` refuses until this is merged. Then:

```bash
bash scripts/implementer/install-tick.sh
echo 'IMPLEMENTER_TICK_ENABLED=1' >> ~/.config/whispershortcut-implementer/env
```

The existing config predates every new key; all the others have working defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
