### PR TITLE
Groom in a worktree of its own, so findings stop waiting on your branch

### DIFF
--- a/plans/agent-loops.md
+++ b/plans/agent-loops.md
@@ -96,13 +96,15 @@ loop jobs (usage · model-audit · growth · architect)
         │ each run drops proposals.json in ~/.local/state/whispershortcut-implementer/incoming
         ▼
 scripts/implementer/tick.sh         ← hourly under launchd
+        │ STEP 1, in its own scratch worktree (.claude/worktrees/implementer-groom), pushing
+        │ straight to origin — so it runs whatever branch YOUR checkout is on:
         │ groom-queue.py: lookups only, no model. instrumentation w/ an OPEN gap → BUILD;
         │ reversible+in-scope+falsifiable → VETO (announced by mail, builds on silence);
         │ everything else → ASK. Ripe VETO windows promote to BUILD.
         ▼
 plans/implementer-queue.md          ← YOU set Flag=BUILD, or stop a VETO row: veto.sh <#>
         │
-scripts/implementer/run-implementer.sh
+scripts/implementer/run-implementer.sh   ← STEP 2, needs your checkout on main
         │ 1. kill switch, lock, main-branch check, pick topmost BUILD/OPEN row
         │ 2. worktree .claude/worktrees/implementer-<slug> on branch implementer/<slug>
         │    build agent (cursor-agent) runs .cursor/skills/implement-proposal/SKILL.md
@@ -242,6 +244,7 @@ Sabaki):
 | "Live" check | `deployment-status.ts` against `/api/version` | App Store version (`asc versions list`) / GitHub release for customer metrics; rebuilt local app for own-usage metrics | Different deploy targets, same deploy gate |
 | Implementer review surface | Branch deployed to a gated dev instance with sanitized prod data | The built app itself — you run the branch build (dogfood-as-review) | No server, no database; the app *is* the artifact |
 | Implementer test gate | `npm run test:web` in the worktree | `xcodebuild test`, which requires killing the running app — the runner relaunches the user's **main** build after each gate | Mid-run the branch has not been judged yet, so the app the user works in must not be swapped for it |
+| Groom lane | Runs in a worktree when the shared tree is busy | Same — a scratch worktree detached at `origin/main`, pushing `HEAD:main` | Findings must never wait on the operator's working state. Sabaki lost eight days and 28 proposals to a global branch guard; this repo copied the guard, then the fix |
 | After a green run | Branch is deployed to a gated dev instance | The runner leaves the **branch build running** as the user's app (`IMPLEMENTER_LAUNCH_BRANCH_BUILD=1`, asked for 2026-09-03) | There is no dev instance; the app *is* the review artifact, and a change you have to launch yourself is a change you do not try. Only after every gate and the reviewer's APPROVE — a failed run always restores the user's own build |
 | Implementer auto lane | `scorer-fix` (a failing eval-corpus case is red→green) and `instrumentation` build with no announcement | `instrumentation` only — there is no eval corpus here | The auto lane may only hold classes an existing gate already judges; inventing one to match Sabaki would be the loosening the policy forbids |
 | Proposal transport | routines write JSON to `~/.local/state/sabaki-implementer/incoming`, groomer is TypeScript | identical shape, groomer is Python (`groom-queue.py`) | No node toolchain in a Swift repo; a dependency nobody maintains is a scheduled job that dies silently |

--- a/scripts/implementer/tick.sh
+++ b/scripts/implementer/tick.sh
@@ -4,9 +4,12 @@
 # Architecture: plans/agent-loops.md. Ported from sabaki.dance's scripts/implementer/tick.sh,
 # including the three failures that lane paid for and this one does not have to repeat again.
 #
-# Two steps, in this order, each skippable without blocking the next:
-#   1. groom the queue  (groom-queue.py) — file loop proposals, promote ripe VETO rows
-#   2. start the next build (run-implementer.sh) — takes the topmost BUILD/OPEN row
+# Two steps, and the difference between them is what this file is shaped around:
+#   1. groom the queue  (groom-queue.py) — file loop proposals, promote ripe VETO rows.
+#      Runs in a scratch worktree of its own and pushes to origin, so it does NOT care which
+#      branch your checkout is on. Findings must never wait on your working state.
+#   2. start the next build (run-implementer.sh) — takes the topmost BUILD/OPEN row. This one
+#      genuinely needs the shared checkout on main, and is guarded there rather than globally.
 #
 # The tick never decides anything. Every build it starts was released either by you flagging a
 # row BUILD, or by a veto window running out while you said nothing.
@@ -75,71 +78,154 @@ done
 
 log "tick start (repo ${REPO_ROOT})"
 
-# --- Is the shared checkout usable? ----------------------------------------------------------
-# Both steps write in the main checkout, so both need it on main and clean. This guard used to
-# be Sabaki's worst blocker: it sat at the top and killed the whole tick, so 28 proposals piled
-# up unread for eight days while the queue kept showing the same three hand-written rows. The
-# fix there was per-step guards; the fix here is the same guard plus LOUD reporting, because a
-# blocked lane that only whispers into a log file is indistinguishable from a quiet week.
+# --- Only one tick at a time -----------------------------------------------------------------
+# A groom that takes longer than the interval would otherwise meet the next tick inside the same
+# worktree. mkdir is atomic and macOS ships no flock(1). The runner keeps its own separate lock.
+TICK_LOCK="/tmp/whispershortcut-implementer-tick.lock.d"
+if ! mkdir "$TICK_LOCK" 2>/dev/null; then
+    log "another tick is still running (${TICK_LOCK}) — skipping this one."
+    exit 0
+fi
+trap 'rmdir "$TICK_LOCK" 2>/dev/null' EXIT
+
+git -C "$REPO_ROOT" fetch -q origin main || warn "could not fetch origin/main — working from what is on disk"
+
+# --- 1. Groom — in its own worktree, whatever the shared checkout is doing --------------------
+# Grooming only reads loop proposals and writes queue bookkeeping. It has no business depending
+# on which branch you happen to be working on, and until 2026-09-03 it did: a tick that found
+# the shared checkout on a feature branch groomed nothing, so proposals piled up unread. That is
+# exactly how Sabaki lost eight days and 28 proposals. So the groomer gets a scratch worktree of
+# its own, detached at origin/main, and pushes straight to origin — the shared checkout is never
+# touched, which also removes the local-main divergence #53 had to repair.
+GROOM_WT="${REPO_ROOT}/.claude/worktrees/implementer-groom"
+
+# Every `git -C "$GROOM_WT"` below is only safe once this returns 0. Verified on 2026-09-03 by
+# getting it wrong: an earlier version checked whether the worktree had FILES, which it did, and
+# went ahead — but git's own idea of the working directory still pointed at the module gitdir, so
+# `reset --hard` checked a full source tree out into `.git/modules/whisper-shortcut/`. Nothing
+# was corrupted, but that is the failure mode to design against: with a wrong `core.worktree`,
+# every write lands somewhere nobody is looking.
+groom_worktree_is_sane() {
+    [[ "$(git -C "$GROOM_WT" rev-parse --show-toplevel 2>/dev/null)" == "$GROOM_WT" ]]
+}
+
+ensure_groom_worktree() {
+    if [[ ! -e "${GROOM_WT}/.git" ]]; then
+        rm -rf "$GROOM_WT"
+        git -C "$REPO_ROOT" worktree prune
+        git -C "$REPO_ROOT" worktree add -q --detach "$GROOM_WT" origin/main || return 1
+    fi
+
+    # This repo is a git submodule, and the shared module config sets `core.worktree`, which
+    # overrides every linked worktree. `git worktree add` writes the files anyway, so the
+    # directory LOOKS right while every later git command operates on the wrong tree. The
+    # per-worktree `config.worktree` file is the fix; `extensions.worktreeConfig` is already on.
+    if ! groom_worktree_is_sane; then
+        local gitdir
+        gitdir=$(sed -n 's/^gitdir: //p' "${GROOM_WT}/.git" 2>/dev/null)
+        if [[ -z "$gitdir" || ! -d "$gitdir" ]]; then
+            warn "groom worktree has no resolvable gitdir — refusing to touch it"
+            return 1
+        fi
+        printf '[core]\n\tworktree = %s\n' "$GROOM_WT" >"${gitdir}/config.worktree"
+        log "repaired the groom worktree's core.worktree (submodule quirk)"
+    fi
+    # Re-checked, not assumed: if the repair did not take, every command below would write into
+    # the gitdir. Stop instead — a tick that grooms nothing is recoverable, this is not.
+    if ! groom_worktree_is_sane; then
+        warn "groom worktree still resolves to $(git -C "$GROOM_WT" rev-parse --show-toplevel 2>/dev/null) — refusing to run git in it"
+        return 1
+    fi
+
+    # Unpushed commits from an earlier tick are REBASED, never reset away. The groomer archives a
+    # proposal file the moment it files the row, so discarding the commit would lose the finding
+    # for good — the one irreversible thing in this whole lane.
+    if [[ -n "$(git -C "$GROOM_WT" log --oneline origin/main..HEAD 2>/dev/null)" ]]; then
+        warn "groom worktree carries unpushed commits from an earlier tick — rebasing, not resetting"
+        git -C "$GROOM_WT" rebase -q origin/main || {
+            git -C "$GROOM_WT" rebase --abort 2>/dev/null
+            warn "rebase failed — leaving the worktree as it is so nothing is lost; fix it by hand at ${GROOM_WT}"
+            return 1
+        }
+    else
+        git -C "$GROOM_WT" reset -q --hard origin/main || return 1
+    fi
+}
+
+if [[ "${IMPLEMENTER_GROOM:-1}" == "1" ]]; then
+    log "step 1: grooming the queue (worktree ${GROOM_WT})"
+    if ensure_groom_worktree; then
+        # The copy IN the worktree, so every path it derives lands there and not in your checkout.
+        python3 "${GROOM_WT}/scripts/implementer/groom-queue.py" \
+            || warn "groom-queue.py exited non-zero — see above"
+        if [[ -n "$(git -C "$GROOM_WT" log --oneline origin/main..HEAD 2>/dev/null)" ]]; then
+            if git -C "$GROOM_WT" push -q origin HEAD:main; then
+                log "pushed queue bookkeeping to origin/main"
+            else
+                # Most likely origin moved while we groomed. One rebase-and-retry; if that fails
+                # the commit stays in the worktree and the next tick picks it up above.
+                warn "push rejected — rebasing on the current origin/main and retrying once"
+                if git -C "$GROOM_WT" pull -q --rebase origin main \
+                    && git -C "$GROOM_WT" push -q origin HEAD:main; then
+                    log "pushed queue bookkeeping to origin/main (after rebase)"
+                else
+                    warn "queue commit still unpushed — kept in the worktree, retried next tick"
+                fi
+            fi
+        fi
+    else
+        warn "could not prepare the groom worktree — nothing groomed this tick"
+    fi
+else
+    log "step 1: skipped (IMPLEMENTER_GROOM=0)"
+fi
+
+# --- 2. Build — this one really does need the shared checkout ---------------------------------
+# The runner builds in a worktree it creates from the shared checkout's `main`, so unlike
+# grooming it cannot proceed while you are on a feature branch. Guarding it here rather than at
+# the top is the whole point of this restructure: a busy checkout now costs you builds, not
+# findings.
 BLOCK_STAMP="${TICK_LOG_DIR}/.blocked-since"
+REPORTED_FILE="${BLOCK_STAMP}.reported"
 CURRENT_BRANCH=$(git -C "$REPO_ROOT" symbolic-ref --short HEAD 2>/dev/null || echo '(detached)')
 if [[ "$CURRENT_BRANCH" != "main" ]]; then
-    warn "main checkout is on '${CURRENT_BRANCH}' — the tick cannot groom or build until it is back on main."
+    warn "step 2 skipped: shared checkout is on '${CURRENT_BRANCH}'. Grooming ran; builds wait for main."
     [[ -f "$BLOCK_STAMP" ]] || date +%s >"$BLOCK_STAMP"
     BLOCKED_HOURS=$(( ($(date +%s) - $(cat "$BLOCK_STAMP")) / 3600 ))
     # Report once a day, not once an hour — an alert that fires 24 times becomes noise, and
     # noise is how the eight-day blockage stayed invisible in the first place.
     #
     # Against a threshold, not `% 24 == 0`: this is a laptop, so ticks are skipped whenever the
-    # lid is shut. A modulo test needs to land on the exact hour and would jump 23 → 25 over a
-    # closed night — silently never reporting, which is the failure this whole block exists to
+    # lid is shut. A modulo test needs to land on the exact hour and would step straight over it
+    # across a closed night — silently never reporting, which is the failure this exists to
     # prevent. The last reported milestone is remembered instead.
-    REPORTED_FILE="${BLOCK_STAMP}.reported"
     LAST_REPORTED=$(cat "$REPORTED_FILE" 2>/dev/null || echo 0)
     if (( BLOCKED_HOURS >= LAST_REPORTED + 24 )); then
         echo "$BLOCKED_HOURS" >"$REPORTED_FILE"
         NOTE=$(mktemp -t wstickblocked)
         {
-            echo "VERDICT: implementer tick BLOCKED for ${BLOCKED_HOURS}h — checkout is on '${CURRENT_BRANCH}'."
+            echo "VERDICT: implementer builds paused ${BLOCKED_HOURS}h — checkout is on '${CURRENT_BRANCH}'."
             echo
-            echo "Nothing has been groomed or built since then. Loop proposals are accumulating in"
-            echo "\${IMPLEMENTER_INCOMING_DIR:-~/.local/state/whispershortcut-implementer/incoming}."
+            echo "Grooming is unaffected and has kept running: proposals are still being filed and"
+            echo "veto windows still promote. What is waiting is the build lane."
+            echo "Released rows sit in plans/implementer-queue.md until then."
             echo "Fix: git -C ${REPO_ROOT} checkout main"
         } >"$NOTE"
         python3 "${REPO_ROOT}/scripts/send-report-mail.py" --to "${AUDIT_MAIL_TO:-mail@magnus-goedde.de}" \
-            --subject "WhisperShortcut implementer tick BLOCKED (${BLOCKED_HOURS}h)" --body-file "$NOTE" \
-            || osascript -e "display notification \"on branch ${CURRENT_BRANCH} for ${BLOCKED_HOURS}h\" with title \"Implementer tick blocked\"" >/dev/null 2>&1
+            --subject "WhisperShortcut implementer builds paused (${BLOCKED_HOURS}h)" --body-file "$NOTE" \
+            || osascript -e "display notification \"on branch ${CURRENT_BRANCH} for ${BLOCKED_HOURS}h\" with title \"Implementer builds paused\"" >/dev/null 2>&1
         rm -f "$NOTE"
     fi
+    log "tick done (groom only)"
     exit 0
 fi
-rm -f "$BLOCK_STAMP" "${BLOCK_STAMP}.reported"
+rm -f "$BLOCK_STAMP" "$REPORTED_FILE"
 
-# --- Sync with origin first ------------------------------------------------------------------
-# The groomer commits queue rows to the LOCAL main and, until 2026-09-03, nothing ever pushed
-# them. Every merged PR then left local main diverged from origin — the first one did, within
-# hours — and the operator's next `git pull` refused to fast-forward. So: rebase onto origin
-# before writing, push after. Both are best-effort; the tick runs hourly, so a push that fails
-# now (offline, lid just opened) simply lands on the next tick. Loud on failure, never fatal.
-git -C "$REPO_ROOT" pull -q --rebase origin main \
-    || warn "could not rebase main onto origin/main — grooming on a possibly stale main"
+# Fast-forward only: the groomer no longer commits here, so local main has nothing of its own to
+# preserve, and anything that would need a merge is yours and not mine to resolve.
+git -C "$REPO_ROOT" merge -q --ff-only origin/main 2>/dev/null \
+    || warn "shared main could not be fast-forwarded to origin/main — the build may use a stale base"
 
-# --- 1. Groom --------------------------------------------------------------------------------
-if [[ "${IMPLEMENTER_GROOM:-1}" == "1" ]]; then
-    log "step 1: grooming the queue"
-    python3 "${SCRIPT_DIR}/groom-queue.py" || warn "groom-queue.py exited non-zero — see above"
-    # Only push what the groomer just wrote — the tree was clean and on main going in, so any
-    # unpushed commit here is the queue bookkeeping and nothing else.
-    if [[ -n "$(git -C "$REPO_ROOT" log --oneline origin/main..main 2>/dev/null)" ]]; then
-        git -C "$REPO_ROOT" push -q origin main \
-            && log "pushed queue bookkeeping to origin/main" \
-            || warn "queue commit not pushed — will retry on the next tick"
-    fi
-else
-    log "step 1: skipped (IMPLEMENTER_GROOM=0)"
-fi
-
-# --- 2. Build --------------------------------------------------------------------------------
 # The runner does its own preflight (lock, monthly budget, scope, clean tree) and exits 0 with
 # "nothing to do" when no BUILD/OPEN row exists, which is the common case. Let it decide.
 log "step 2: starting the next build if one is due"


### PR DESCRIPTION
The tick guarded **both** its steps on the shared checkout being on `main`. An hour spent on a feature branch therefore groomed nothing: loop proposals sat unread in the incoming directory and veto windows did not promote. That is the exact failure sabaki.dance paid eight days and 28 proposals for — the guard was copied here, the fix that followed it was not.

## Change

Grooming only reads proposals and writes queue bookkeeping, so it now runs in a **scratch worktree detached at `origin/main`** (`.claude/worktrees/implementer-groom`) and pushes `HEAD:main` directly. Your checkout is never written to.

That also removes, by construction, the local-`main` divergence [#53](https://github.com/mgsgde/whisper-shortcut/pull/53) had to repair — so that logic moves here instead of staying. Only step 2 (the build) still needs your checkout on `main`, and it is guarded there. **A busy checkout now costs you builds, not findings**, and the 24-hour alert says so.

## Two things this had to get right — both learned by getting them wrong first

**1. The submodule `core.worktree` trap.** The shared module config sets `core.worktree`, which overrides every linked worktree. `git worktree add` writes the files anyway, so the directory *looks* correct while git still resolves the working tree to `.git/modules/whisper-shortcut/`. The first version of this checked whether the worktree had files, found them, and proceeded — and `reset --hard` checked a full source tree out into the module gitdir.

Nothing was corrupted and the strays are removed, but that is the hazard worth designing against: with a wrong `core.worktree`, every write lands somewhere nobody is looking. The check is now `rev-parse --show-toplevel`, **re-verified after the repair**, and the tick refuses to run any git command in the worktree if it still disagrees.

**2. Unpushed commits are rebased, never reset away.** The groomer archives a proposal file the moment it files the row, so discarding that commit would lose the finding for good — the only irreversible step in the lane. A rejected push gets one rebase-and-retry, then waits for the next tick.

Also adds a tick-level lock: hourly runs must not meet inside one worktree.

## Verified against the real shared checkout, both branches of the guard

- On `probe/groom-worktree-check`: the tick groomed a probe row and **pushed it to `origin/main`** (queue row 5, since removed) while the checkout stayed on its branch, clean and untouched.
- On `main`: both steps ran, checkout clean and in sync afterwards.
- Module gitdir clean in both cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
