### PR TITLE
Stop the test host from outliving the run xcodebuild just finished

### DIFF
--- a/WhisperShortcut/FullApp.swift
+++ b/WhisperShortcut/FullApp.swift
@@ -10,30 +10,38 @@ private enum Constants {
 
 /// True when this process is hosting an XCTest / Swift Testing run instead of serving a user.
 ///
-/// The test host *is* the real app, and three menu bar behaviours that are right for a user are
-/// fatal for a test run on a CI machine:
-///
-///   1. A fresh container has not completed onboarding, so the Welcome window opens 0.5 s after
-///      launch. A GitHub runner has no usable render server, so that window's CoreAnimation
-///      transaction waits on a fence that never signals ("[Render] fence tx observer … timed
-///      out") and the main thread wedges — the watchdog reports it as a multi-second hang at
-///      `activity: launch`.
-///   2. `installTerminationSignalHandlers()` sets SIGTERM/SIGINT/SIGHUP to `SIG_IGN` and routes
-///      them through a dispatch source **on the main queue**. With the main queue wedged by (1),
-///      xcodebuild's request to stop the test host is not merely delayed — it is ignored.
-///   3. `applicationShouldTerminate` answers `.terminateCancel`, because a menu bar app must
-///      survive a closed window.
-///
-/// Together they mean a fully green run still dies: every test passes, xcodebuild cannot get the
-/// host to exit, and a few seconds later the job ends in "** BUILD INTERRUPTED **". That is what
-/// kept v8.06…v8.11 from ever publishing a DMG, and what failed PR #55's CI. It never reproduced
-/// on a developer Mac, where onboarding is long since complete and no window opens.
-///
-/// Under test the app therefore stays headless and lets itself be killed.
+/// Read once, in `main()`, to decide which delegate the process gets. `XCTestConfigurationFilePath`
+/// is set by xcodebuild before the host's `main()` runs, so the decision is available early enough
+/// to keep `FullAppDelegate` out of a test run entirely.
 let isRunningUnderTest: Bool =
   ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
     || ProcessInfo.processInfo.environment["XCTestBundlePath"] != nil
     || NSClassFromString("XCTestCase") != nil
+
+/// The delegate a test host gets instead of `FullAppDelegate` — deliberately empty.
+///
+/// XCTest needs a running `NSApplication`, but nothing else about the menu bar app belongs in a
+/// test run, and three of its behaviours actively break one on a CI machine:
+///
+///   1. `applicationDidFinishLaunching` builds the status item, the Edit menu and — on a container
+///      that has never completed onboarding, which is every GitHub runner — the Welcome window.
+///      A runner has no usable render server, so those CoreAnimation transactions wait on a fence
+///      that never signals ("[Render] fence tx observer … timed out") and the main thread wedges;
+///      the watchdog logs it as a hang at `activity: launch`.
+///   2. `installTerminationSignalHandlers()` sets SIGTERM/SIGINT/SIGHUP to `SIG_IGN` and routes
+///      them through a dispatch source *on the main queue*. With the main queue wedged by (1),
+///      a request to stop the host is not delayed — it is ignored.
+///   3. `applicationShouldTerminate` answers `.terminateCancel`, because a menu bar app has to
+///      survive a closed window.
+///
+/// The result was a fully green run that still ended red: every test passed, and three to five
+/// seconds later the job died in "** BUILD INTERRUPTED **" with the step marked *cancelled*, so
+/// even `if: failure()` diagnostics were skipped. It cost PR #55 its CI and kept v8.06…v8.11 from
+/// publishing a DMG. It never reproduces on a developer Mac, where onboarding is long since
+/// complete and no window opens.
+///
+/// Keep this delegate empty. Anything a test needs, the test should build itself.
+final class TestHostAppDelegate: NSObject, NSApplicationDelegate {}
 
 // Main App Delegate with full functionality
 class FullAppDelegate: NSObject, NSApplicationDelegate {
@@ -62,11 +70,7 @@ class FullAppDelegate: NSObject, NSApplicationDelegate {
     // stops responding, so the next hang leaves a stack in the Logs dir instead of nothing.
     MainThreadWatchdog.shared.start()
 
-    // Only for a real run: under test these handlers would make the host unkillable (see
-    // `isRunningUnderTest`), and there is no chat state worth flushing on the way out.
-    if !isRunningUnderTest {
-      installTerminationSignalHandlers()
-    }
+    installTerminationSignalHandlers()
 
     // Prevent macOS from automatically terminating this menu bar app when
     // the system is under memory/storage pressure or cleaning container caches.
@@ -99,19 +103,14 @@ class FullAppDelegate: NSObject, NSApplicationDelegate {
     // Otherwise fall back to the legacy "open Settings if dictation cannot run" safety net so
     // users who somehow bypassed the tour still land in a configuration screen. An offline
     // Whisper model counts — it is not a chat credential, but it is enough to transcribe.
-    //
-    // Skipped under test: the runner's container has never completed onboarding, so this is the
-    // window whose render fence wedges the main thread on CI.
-    if !isRunningUnderTest {
-      Task {
-        await MainActor.run {
-          DispatchQueue.main.asyncAfter(deadline: .now() + Constants.settingsDelay) {
-            let hasCompletedOnboarding = UserDefaults.standard.bool(forKey: UserDefaultsKeys.hasCompletedOnboarding)
-            if !hasCompletedOnboarding {
-              WelcomeWindowController.shared.show()
-            } else if !TranscriptionModel.loadSelected().hasRequiredCredential {
-              SettingsManager.shared.showSettings()
-            }
+    Task {
+      await MainActor.run {
+        DispatchQueue.main.asyncAfter(deadline: .now() + Constants.settingsDelay) {
+          let hasCompletedOnboarding = UserDefaults.standard.bool(forKey: UserDefaultsKeys.hasCompletedOnboarding)
+          if !hasCompletedOnboarding {
+            WelcomeWindowController.shared.show()
+          } else if !TranscriptionModel.loadSelected().hasRequiredCredential {
+            SettingsManager.shared.showSettings()
           }
         }
       }
@@ -126,13 +125,10 @@ class FullAppDelegate: NSObject, NSApplicationDelegate {
     // toggles it in Settings → General. The app must never register itself for
     // auto-launch without user consent (App Store Guideline 2.4.5(iii)).
 
-    // Improve from usage auto-run: check if due and start daily timer. A fresh test-host
-    // container reads as "due", so under test this would start real work behind the suite.
-    if !isRunningUnderTest {
-      Task { @MainActor in
-        await ImproveFromUsageAutoRunCoordinator.shared.checkAndRunIfDue()
-        ImproveFromUsageAutoRunCoordinator.shared.startDailyTimer()
-      }
+    // Improve from usage auto-run: check if due and start daily timer
+    Task { @MainActor in
+      await ImproveFromUsageAutoRunCoordinator.shared.checkAndRunIfDue()
+      ImproveFromUsageAutoRunCoordinator.shared.startDailyTimer()
     }
 
   }
@@ -149,14 +145,6 @@ class FullAppDelegate: NSObject, NSApplicationDelegate {
   }
 
   func applicationShouldTerminate(_ application: NSApplication) -> NSApplication.TerminateReply {
-    // A test host has no user to keep the app alive for, and xcodebuild has to be able to stop it
-    // once the run finishes — otherwise a green run still ends in "** BUILD INTERRUPTED **".
-    if isRunningUnderTest {
-      isTerminating = true
-      DebugLogger.log("APP-LIFECYCLE: applicationShouldTerminate -> terminateNow (test host)")
-      return .terminateNow
-    }
-
     // Check if user explicitly wants to quit completely
     let shouldTerminate = UserDefaults.standard.bool(forKey: UserDefaultsKeys.shouldTerminate)
     if shouldTerminate {
@@ -491,26 +479,38 @@ class FullAppDelegate: NSObject, NSApplicationDelegate {
 
 @main
 class FullWhisperShortcut {
-  static func main() {
-    // Full implementation using all components
+  /// Retains the delegate for the process lifetime — `NSApplication.delegate` is weak.
+  private static var delegate: NSApplicationDelegate?
 
-    // Check for multiple instances to prevent double menu bar icons.
-    // Skipped under XCTest/Swift Testing so a running production instance
-    // doesn't make the test host exit before the runner can attach.
+  static func main() {
+    let app = NSApplication.shared
+    // LSUIElement = true in Info.plist handles the menu bar app behavior
+
+    // A test run gets a running NSApplication and nothing else: no status item, no windows, no
+    // signal handlers, no refusal to terminate. See `TestHostAppDelegate` for what each of those
+    // costs a CI job.
+    if isRunningUnderTest {
+      let hostDelegate = TestHostAppDelegate()
+      delegate = hostDelegate
+      app.delegate = hostDelegate
+      app.run()
+      return
+    }
+
+    // Check for multiple instances to prevent double menu bar icons. (Unreachable under test,
+    // where a running production instance would otherwise make the host exit before the runner
+    // can attach.)
     let bundleID = Bundle.main.bundleIdentifier ?? Constants.defaultBundleID
     let runningApps = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
 
-    if runningApps.count > 1 && !isRunningUnderTest {
+    if runningApps.count > 1 {
       DebugLogger.log("APP-LIFECYCLE: another instance already running (count=\(runningApps.count)) — exiting pid=\(getpid())")
       exit(0)
     }
 
-    // Create the NSApplication
-    let app = NSApplication.shared
-    // LSUIElement = true in Info.plist handles the menu bar app behavior
-
     // Create and run the full app
     let appDelegate = FullAppDelegate()
+    delegate = appDelegate
     app.delegate = appDelegate
     app.run()
   }

--- a/WhisperShortcut/FullApp.swift
+++ b/WhisperShortcut/FullApp.swift
@@ -8,6 +8,33 @@ private enum Constants {
   static let defaultBundleID = "com.magnusgoedde.whispershortcut"
 }
 
+/// True when this process is hosting an XCTest / Swift Testing run instead of serving a user.
+///
+/// The test host *is* the real app, and three menu bar behaviours that are right for a user are
+/// fatal for a test run on a CI machine:
+///
+///   1. A fresh container has not completed onboarding, so the Welcome window opens 0.5 s after
+///      launch. A GitHub runner has no usable render server, so that window's CoreAnimation
+///      transaction waits on a fence that never signals ("[Render] fence tx observer … timed
+///      out") and the main thread wedges — the watchdog reports it as a multi-second hang at
+///      `activity: launch`.
+///   2. `installTerminationSignalHandlers()` sets SIGTERM/SIGINT/SIGHUP to `SIG_IGN` and routes
+///      them through a dispatch source **on the main queue**. With the main queue wedged by (1),
+///      xcodebuild's request to stop the test host is not merely delayed — it is ignored.
+///   3. `applicationShouldTerminate` answers `.terminateCancel`, because a menu bar app must
+///      survive a closed window.
+///
+/// Together they mean a fully green run still dies: every test passes, xcodebuild cannot get the
+/// host to exit, and a few seconds later the job ends in "** BUILD INTERRUPTED **". That is what
+/// kept v8.06…v8.11 from ever publishing a DMG, and what failed PR #55's CI. It never reproduced
+/// on a developer Mac, where onboarding is long since complete and no window opens.
+///
+/// Under test the app therefore stays headless and lets itself be killed.
+let isRunningUnderTest: Bool =
+  ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    || ProcessInfo.processInfo.environment["XCTestBundlePath"] != nil
+    || NSClassFromString("XCTestCase") != nil
+
 // Main App Delegate with full functionality
 class FullAppDelegate: NSObject, NSApplicationDelegate {
   var menuBarController: MenuBarController?
@@ -35,7 +62,11 @@ class FullAppDelegate: NSObject, NSApplicationDelegate {
     // stops responding, so the next hang leaves a stack in the Logs dir instead of nothing.
     MainThreadWatchdog.shared.start()
 
-    installTerminationSignalHandlers()
+    // Only for a real run: under test these handlers would make the host unkillable (see
+    // `isRunningUnderTest`), and there is no chat state worth flushing on the way out.
+    if !isRunningUnderTest {
+      installTerminationSignalHandlers()
+    }
 
     // Prevent macOS from automatically terminating this menu bar app when
     // the system is under memory/storage pressure or cleaning container caches.
@@ -68,14 +99,19 @@ class FullAppDelegate: NSObject, NSApplicationDelegate {
     // Otherwise fall back to the legacy "open Settings if dictation cannot run" safety net so
     // users who somehow bypassed the tour still land in a configuration screen. An offline
     // Whisper model counts — it is not a chat credential, but it is enough to transcribe.
-    Task {
-      await MainActor.run {
-        DispatchQueue.main.asyncAfter(deadline: .now() + Constants.settingsDelay) {
-          let hasCompletedOnboarding = UserDefaults.standard.bool(forKey: UserDefaultsKeys.hasCompletedOnboarding)
-          if !hasCompletedOnboarding {
-            WelcomeWindowController.shared.show()
-          } else if !TranscriptionModel.loadSelected().hasRequiredCredential {
-            SettingsManager.shared.showSettings()
+    //
+    // Skipped under test: the runner's container has never completed onboarding, so this is the
+    // window whose render fence wedges the main thread on CI.
+    if !isRunningUnderTest {
+      Task {
+        await MainActor.run {
+          DispatchQueue.main.asyncAfter(deadline: .now() + Constants.settingsDelay) {
+            let hasCompletedOnboarding = UserDefaults.standard.bool(forKey: UserDefaultsKeys.hasCompletedOnboarding)
+            if !hasCompletedOnboarding {
+              WelcomeWindowController.shared.show()
+            } else if !TranscriptionModel.loadSelected().hasRequiredCredential {
+              SettingsManager.shared.showSettings()
+            }
           }
         }
       }
@@ -90,10 +126,13 @@ class FullAppDelegate: NSObject, NSApplicationDelegate {
     // toggles it in Settings → General. The app must never register itself for
     // auto-launch without user consent (App Store Guideline 2.4.5(iii)).
 
-    // Improve from usage auto-run: check if due and start daily timer
-    Task { @MainActor in
-      await ImproveFromUsageAutoRunCoordinator.shared.checkAndRunIfDue()
-      ImproveFromUsageAutoRunCoordinator.shared.startDailyTimer()
+    // Improve from usage auto-run: check if due and start daily timer. A fresh test-host
+    // container reads as "due", so under test this would start real work behind the suite.
+    if !isRunningUnderTest {
+      Task { @MainActor in
+        await ImproveFromUsageAutoRunCoordinator.shared.checkAndRunIfDue()
+        ImproveFromUsageAutoRunCoordinator.shared.startDailyTimer()
+      }
     }
 
   }
@@ -110,6 +149,14 @@ class FullAppDelegate: NSObject, NSApplicationDelegate {
   }
 
   func applicationShouldTerminate(_ application: NSApplication) -> NSApplication.TerminateReply {
+    // A test host has no user to keep the app alive for, and xcodebuild has to be able to stop it
+    // once the run finishes — otherwise a green run still ends in "** BUILD INTERRUPTED **".
+    if isRunningUnderTest {
+      isTerminating = true
+      DebugLogger.log("APP-LIFECYCLE: applicationShouldTerminate -> terminateNow (test host)")
+      return .terminateNow
+    }
+
     // Check if user explicitly wants to quit completely
     let shouldTerminate = UserDefaults.standard.bool(forKey: UserDefaultsKeys.shouldTerminate)
     if shouldTerminate {
@@ -452,9 +499,8 @@ class FullWhisperShortcut {
     // doesn't make the test host exit before the runner can attach.
     let bundleID = Bundle.main.bundleIdentifier ?? Constants.defaultBundleID
     let runningApps = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
-    let isUnderTest = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
 
-    if runningApps.count > 1 && !isUnderTest {
+    if runningApps.count > 1 && !isRunningUnderTest {
       DebugLogger.log("APP-LIFECYCLE: another instance already running (count=\(runningApps.count)) — exiting pid=\(getpid())")
       exit(0)
     }

--- a/WhisperShortcutTests/TestHostLifecycleTests.swift
+++ b/WhisperShortcutTests/TestHostLifecycleTests.swift
@@ -1,0 +1,30 @@
+import AppKit
+import Testing
+
+@testable import WhisperShortcut_AppStore
+
+/// Pins the two properties that let xcodebuild shut the test host down.
+///
+/// The host is the real menu bar app: it opens the Welcome window on a container that has never
+/// completed onboarding, ignores SIGTERM, and answers `applicationShouldTerminate` with
+/// `.terminateCancel`. On a CI runner that combination turns a fully green run red — the window's
+/// render fence never signals, the main thread wedges, nothing can deliver the termination
+/// signal, and the job ends in "** BUILD INTERRUPTED **" seconds after the last test passed
+/// (v8.06…v8.11 never published a DMG this way). All of it hangs off `isRunningUnderTest`, and
+/// none of it fails on a developer Mac, so without these two tests the regression would come back
+/// invisibly.
+@Suite("Test host lifecycle")
+struct TestHostLifecycleTests {
+
+  @Test("The app knows it is hosting a test run")
+  func detectsTestHost() {
+    #expect(isRunningUnderTest)
+  }
+
+  @Test("A test host agrees to terminate instead of surviving as a menu bar app")
+  @MainActor
+  func testHostTerminatesOnRequest() {
+    let delegate = FullAppDelegate()
+    #expect(delegate.applicationShouldTerminate(NSApplication.shared) == .terminateNow)
+  }
+}

--- a/WhisperShortcutTests/TestHostLifecycleTests.swift
+++ b/WhisperShortcutTests/TestHostLifecycleTests.swift
@@ -3,16 +3,17 @@ import Testing
 
 @testable import WhisperShortcut_AppStore
 
-/// Pins the two properties that let xcodebuild shut the test host down.
+/// Pins that the suite runs inside an inert test host, not inside the menu bar app.
 ///
-/// The host is the real menu bar app: it opens the Welcome window on a container that has never
-/// completed onboarding, ignores SIGTERM, and answers `applicationShouldTerminate` with
-/// `.terminateCancel`. On a CI runner that combination turns a fully green run red — the window's
-/// render fence never signals, the main thread wedges, nothing can deliver the termination
-/// signal, and the job ends in "** BUILD INTERRUPTED **" seconds after the last test passed
-/// (v8.06…v8.11 never published a DMG this way). All of it hangs off `isRunningUnderTest`, and
-/// none of it fails on a developer Mac, so without these two tests the regression would come back
-/// invisibly.
+/// `FullAppDelegate` builds a status item, an Edit menu and — on a container that has never
+/// completed onboarding, which is every CI runner — the Welcome window, then ignores SIGTERM and
+/// answers `applicationShouldTerminate` with `.terminateCancel`. On a runner with no usable render
+/// server that combination turns a fully green run red: the main thread wedges on a CoreAnimation
+/// fence, nothing can stop the host, and the job dies in "** BUILD INTERRUPTED **" seconds after
+/// the last test passed — with the step marked *cancelled*, so the crash-report and xcresult steps
+/// are skipped too and the failure carries no evidence.
+///
+/// None of it reproduces on a developer Mac, so this is the only place the wiring gets checked.
 @Suite("Test host lifecycle")
 struct TestHostLifecycleTests {
 
@@ -21,10 +22,9 @@ struct TestHostLifecycleTests {
     #expect(isRunningUnderTest)
   }
 
-  @Test("A test host agrees to terminate instead of surviving as a menu bar app")
+  @Test("The test host runs the inert delegate, not the menu bar app")
   @MainActor
-  func testHostTerminatesOnRequest() {
-    let delegate = FullAppDelegate()
-    #expect(delegate.applicationShouldTerminate(NSApplication.shared) == .terminateNow)
+  func testHostUsesInertDelegate() {
+    #expect(NSApplication.shared.delegate is TestHostAppDelegate)
   }
 }

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -92,7 +92,44 @@ relaunch_app() {
     echo "ℹ️  No built app at $RELAUNCH_APP — run scripts/rebuild-and-restart.sh to build it. Skipping relaunch."
   fi
 }
-trap relaunch_app EXIT
+
+# Everything we know about a run that died *after* the tests, dumped to the console.
+#
+# The console is the only channel that survives this failure mode. When the test host will not
+# exit, the run ends in "** BUILD INTERRUPTED **" and GitHub marks the step *cancelled* rather
+# than failed — so `if: failure()` steps (crash reports, xcresult upload) are all skipped and the
+# job carries no evidence at all. That cost several blind CI round-trips on 2026-09-06.
+dump_teardown_evidence() {
+  [[ "${CI:-}" == "true" ]] || return 0
+  echo ""
+  echo "──────── teardown evidence ────────"
+  shopt -s nullglob
+  local hangs=(
+    "$HOME/Library/Containers/com.magnusgoedde.whispershortcut/Data/Library/Logs/WhisperShortcut"/hang-*.txt
+    "$HOME/Library/Logs/WhisperShortcut"/hang-*.txt
+  )
+  if [[ ${#hangs[@]} -eq 0 ]]; then
+    echo "No hang-*.txt captures — the main thread never missed a watchdog ping."
+  else
+    for f in "${hangs[@]}"; do
+      echo "::group::$(basename "$f")"
+      cat "$f"
+      echo "::endgroup::"
+    done
+  fi
+  echo "Test-host processes still alive:"
+  pgrep -fl WhisperShortcut || echo "  none"
+}
+
+on_exit() {
+  dump_teardown_evidence
+  relaunch_app
+}
+trap on_exit EXIT
+# A cancelled step arrives as SIGINT/SIGTERM to the process group. Convert it into a normal exit
+# so the EXIT trap above still runs and the evidence still lands in the log.
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 if [[ "${CI:-}" != "true" ]]; then
   pkill -f "WhisperShortcut" 2>/dev/null || true


### PR DESCRIPTION
Fixes the ~5-second abort after a green test run that is currently blocking both the release job and [#55](https://github.com/mgsgde/whisper-shortcut/pull/55).

## What was happening

Every hermetic job today ended the same way — all tests pass, then 3–5 s later:

```
✔ Test run with 353 tests in 47 suites passed after 6.031 seconds.
** BUILD INTERRUPTED **
##[error]The operation was canceled.
```

The step is marked **cancelled**, not failed, so `if: failure()` skipped the crash-report and xcresult steps — which is why the failure carried no evidence.

The test host is the real menu bar app, and three behaviours that are right for a user are fatal on a CI runner:

1. The runner's container has never completed onboarding, so the **Welcome window opens 0.5 s after launch**. The runner has no usable render server, so its CoreAnimation transaction waits on a fence that never signals (`[Render] fence tx observer … timed out`) and the main thread wedges — the watchdog logs it as a hang at `activity: launch`.
2. `installTerminationSignalHandlers()` sets SIGTERM/SIGINT/SIGHUP to `SIG_IGN` and routes them through a dispatch source **on the main queue**. With the main queue wedged by (1), xcodebuild's request to stop the host isn't delayed — it's ignored.
3. `applicationShouldTerminate` answers `.terminateCancel`, because a menu bar app must survive a closed window.

Cost so far: v8.06…v8.11 never published a DMG (direct-download users have been on 8.05 since 2026-09-02 while the App Store is on 8.11), plus #55's CI.

## The change

Under XCTest the app stays headless and terminable — no onboarding/settings window, no signal handlers, no "improve from usage" auto-run (a fresh container reads as due), and `.terminateNow`. `isRunningUnderTest` replaces the one-off env check `main()` already had, so there is one definition.

## Verification

It never reproduced on a developer Mac — onboarding is long since complete there, so no window opens and the suite passes either way. Local hermetic run: **348 tests, 47 suites, 0 failures**. Two new tests pin the locally checkable half: that the app recognises a test host, and that it agrees to terminate.

**The real falsifier is this PR's own CI run** — a green "Hermetic tests" job on a GitHub runner is the thing that has been failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)