### PR TITLE
Every job mail says whether the operator has to act

### DIFF
--- a/plans/agent-loops.md
+++ b/plans/agent-loops.md
@@ -51,6 +51,10 @@ Architect loop checks for drift on every run:
   whenever the bottleneck is not the thing that loop can move.
 - **Loud failure.** A loop that cannot read its data or write its digest reports a FAILED
   run by mail — silence must never be distinguishable from a quiet week.
+- **Every mail states whether you have to act**, in the same five words in the same place.
+  `scripts/operator_mail.py` holds the vocabulary and renders the banner; `send-report-mail.py`
+  takes it as `--verdict` and is the only sender. Ported from Sabaki's
+  `apps/shared/operator-action.ts` on 2026-09-07 — see "The mail contract" below.
 
 ## Autonomy policy
 
@@ -295,6 +299,7 @@ Sabaki):
 | Implementer test gate | `npm run test:web` in the worktree | `xcodebuild test`, which requires killing the running app — the runner relaunches the user's **main** build after each gate | Mid-run the branch has not been judged yet, so the app the user works in must not be swapped for it |
 | Groom lane | Runs in a worktree when the shared tree is busy | Same — a scratch worktree detached at `origin/main`, pushing `HEAD:main` | Findings must never wait on the operator's working state. Sabaki lost eight days and 28 proposals to a global branch guard; this repo copied the guard, then the fix |
 | After a green run | Branch is deployed to a gated dev instance | The runner leaves the **branch build running** as the user's app (`IMPLEMENTER_LAUNCH_BRANCH_BUILD=1`, asked for 2026-09-03) | There is no dev instance; the app *is* the review artifact, and a change you have to launch yourself is a change you do not try. Only after every gate and the reviewer's APPROVE — a failed run always restores the user's own build |
+| Admin-mail rendering | `apps/shared/html.ts` + `marked`, inside the app's own mailer | `scripts/operator_mail.py`, dependency-free, sent over SMTP by `send-report-mail.py` | Same vocabulary, same banner, same dark palette — but these mails are sent by launchd from a Mac whose system `python3` has no markdown library, and a failed import is a job that reports nothing |
 | Implementer auto lane | `scorer-fix` (a failing eval-corpus case is red→green) and `instrumentation` build with no announcement | `instrumentation` only — there is no eval corpus here | The auto lane may only hold classes an existing gate already judges; inventing one to match Sabaki would be the loosening the policy forbids |
 | Proposal transport | routines write JSON to `~/.local/state/sabaki-implementer/incoming`, groomer is TypeScript | identical shape, groomer is Python (`groom-queue.py`) | No node toolchain in a Swift repo; a dependency nobody maintains is a scheduled job that dies silently |
 
@@ -327,3 +332,49 @@ launchctl unload ~/Library/LaunchAgents/com.whispershortcut.sales-poster.plist
 Every job mails its digest (macOS notification as fallback) and reports failures loudly —
 a loop that silently stops running looks exactly like a quiet week, and that is the one
 failure mode this design exists to rule out.
+
+## The mail contract — every mail answers "muss ich hier etwas tun?"
+
+Ported from sabaki.dance (`apps/shared/operator-action.ts`, 2026-09-06) on 2026-09-07, after the
+usage-review mail of that morning: three screens of analysis, a subject that led with the finding,
+and nothing anywhere saying that one of its proposals was already released to build on a deadline
+two days out and one was waiting for a human. The answer existed in `plans/implementer-queue.md`;
+the mail did not carry it.
+
+A sender picks a **state**, never a sentence (`scripts/operator_mail.py`):
+
+| flag | reads as | when |
+| ---- | -------- | ---- |
+| `--verdict fyi` | ✅ Nothing to do — for your information. | a record of something that happened |
+| `--verdict handled` | ✅ Nothing to do — handled automatically. | `--verdict-handler` names the job that has it |
+| `--verdict ships-on-silence` | ⏳ Nothing to do unless you disagree. | a deadline; `--verdict-stop-with` is the exact stop command |
+| `--verdict needs-decision` | ⚠️ Needs you: N decisions. | `--verdict-count` says how many |
+| `--verdict needs-fix` | 🚨 Needs you: nothing automatic covers this. | broken, and nothing retries it |
+| `--verdict proposals` | derived from `--proposals-file` | the loop jobs: `handled` when the run queued proposals, `fyi` when it queued none |
+
+Rules that make it worth trusting:
+
+- **The verdict is derived from machine facts, never from the run's own summary of itself** — an
+  agent describing its own run is exactly the thing that drifts. The loops count the proposals
+  they actually handed over (`proposal-prompt.sh --path-only` fixes the path so the count is
+  exact); the groomer reads its own lanes; `health-report.py` reads the queue.
+- **Never claim a handler that is not armed.** `--verdict handled` must name a job that really
+  runs: the hourly `com.whispershortcut.implementer-tick`, the weekly health report, the release
+  sweep. When in doubt, use a `needs-*` state — over-claiming automation is the one failure worse
+  than silence.
+- **A sender that passes no `--verdict` still sends**, with an amber "this mail did not say
+  whether you have to act" banner. A mail nobody receives is worse than one whose sender forgot
+  the flag, and the banner makes the gap self-reporting.
+- **The subject carries the verdict, not the finding.** `withVerdictSubject`'s suffix is appended
+  by the mailer; the loops' subjects are the job and the date, because a 120-character finding
+  pushed the answer past where every mail client truncates. The finding still leads the mail body
+  as "In one line:", and the macOS notification still speaks it.
+
+Check what a mail looks like without waiting for a run — including dark mode, which is where a
+regression hides:
+
+```bash
+python3 scripts/send-report-mail.py --subject "…" --body-file plans/…md \
+    --verdict needs-decision --verdict-count 2 --verdict-detail "…" \
+    --dry-run --html-out /tmp/preview.html
+```

--- a/scripts/agent-loops-job.sh
+++ b/scripts/agent-loops-job.sh
@@ -72,9 +72,9 @@ notify() {
 }
 
 report_out() {
-  local subject="$1" body="$2"
+  local subject="$1" body="$2"; shift 2
   if python3 "$REPO/scripts/send-report-mail.py" --to "$AUDIT_MAIL_TO" \
-       --subject "$subject" --body-file "$body"; then
+       --subject "$subject" --body-file "$body" "$@"; then
     return 0
   fi
   echo "WARN: could not send mail — falling back to a local notification"
@@ -86,7 +86,10 @@ fail_out() {
   echo "VERDICT: $verdict"
   local note; note="$(mktemp -t wsloopsfail)"
   { echo "VERDICT: $verdict"; echo; for line in "$@"; do echo "$line"; done; } > "$note"
-  report_out "WhisperShortcut agent-loops review FAILED ($STAMP)" "$note"
+  report_out "WhisperShortcut agent-loops review FAILED ($STAMP)" "$note" \
+    --verdict needs-fix --verdict-detail "$verdict This run produced no proposals, so nothing \
+reached the implementer queue. Nothing retries it — the next scheduled run is a month away \
+unless you re-run it by hand (command below)."
   notify "WhisperShortcut agent-loops review FAILED" "$verdict"
   rm -f "$note"
   exit 1
@@ -141,6 +144,11 @@ EOF
 # a ledger row nobody flags. The schema lives in one place, not four:
 # scripts/implementer/proposal-prompt.sh. Appending is best-effort — a loop whose report is
 # written must not fail because the sidecar prompt could not be generated.
+# The path is fixed here rather than left to the helper's clock, because this run's mail has to
+# say whether anything reached the implementer queue — and "proposed nothing" must not look like
+# "wrote its file under a name nobody counted".
+IMPLEMENTER_PROPOSAL_FILE="$(bash "$REPO/scripts/implementer/proposal-prompt.sh" agent-loops --path-only)"
+export IMPLEMENTER_PROPOSAL_FILE
 bash "$REPO/scripts/implementer/proposal-prompt.sh" agent-loops >>"$PROMPT_FILE" \
   || echo "WARN: could not append the implementer-proposal block — this run reports only."
 
@@ -187,7 +195,14 @@ ln -sf "$(basename "$DIGEST")" "$REVIEW_DIR/LATEST.md"
 
 VERDICT="$(head -1 "$DIGEST" | sed 's/^VERDICT:[[:space:]]*//')"
 [ -n "$VERDICT" ] || VERDICT="Digest written (no verdict line found)"
-report_out "WhisperShortcut agent-loops review — $VERDICT" "$DIGEST"
+# The subject is the job and the date, not the finding. The finding used to lead it and ran to 120
+# characters, which pushed the one thing a phone notification has to show — whether this needs you —
+# past where every mail client truncates. It still leads the mail itself ("In one line:"), and the
+# notification below still speaks it.
+report_out "WhisperShortcut agent-loops review ($STAMP)" "$DIGEST" \
+  --verdict proposals --proposals-file "$IMPLEMENTER_PROPOSAL_FILE" \
+  --title "Agent-loops review $STAMP" \
+  --meta "Job=agent-loops (monthly)" --meta "Digest=$DIGEST"
 notify "WhisperShortcut agent-loops review" "$VERDICT"
 echo "VERDICT: $VERDICT"
 echo "Digest: $DIGEST"

--- a/scripts/growth-review-job.sh
+++ b/scripts/growth-review-job.sh
@@ -83,9 +83,9 @@ notify() {
 }
 
 report_out() {
-  local subject="$1" body="$2"
+  local subject="$1" body="$2"; shift 2
   if python3 "$REPO/scripts/send-report-mail.py" --to "$AUDIT_MAIL_TO" \
-       --subject "$subject" --body-file "$body"; then
+       --subject "$subject" --body-file "$body" "$@"; then
     return 0
   fi
   echo "WARN: could not send mail — falling back to a local notification"
@@ -97,7 +97,10 @@ fail_out() {
   echo "VERDICT: $verdict"
   local note; note="$(mktemp -t wsgrowthfail)"
   { echo "VERDICT: $verdict"; echo; for line in "$@"; do echo "$line"; done; } > "$note"
-  report_out "WhisperShortcut growth review FAILED ($STAMP)" "$note"
+  report_out "WhisperShortcut growth review FAILED ($STAMP)" "$note" \
+    --verdict needs-fix --verdict-detail "$verdict This run produced no proposals, so nothing \
+reached the implementer queue. Nothing retries it — the cadence gate means the next run is two \
+weeks away unless you re-run it by hand (command below)."
   notify "WhisperShortcut growth review FAILED" "$verdict"
   rm -f "$note"
   exit 1
@@ -166,6 +169,11 @@ EOF
 # a ledger row nobody flags. The schema lives in one place, not four:
 # scripts/implementer/proposal-prompt.sh. Appending is best-effort — a loop whose report is
 # written must not fail because the sidecar prompt could not be generated.
+# The path is fixed here rather than left to the helper's clock, because this run's mail has to
+# say whether anything reached the implementer queue — and "proposed nothing" must not look like
+# "wrote its file under a name nobody counted".
+IMPLEMENTER_PROPOSAL_FILE="$(bash "$REPO/scripts/implementer/proposal-prompt.sh" growth-review --path-only)"
+export IMPLEMENTER_PROPOSAL_FILE
 bash "$REPO/scripts/implementer/proposal-prompt.sh" growth-review >>"$PROMPT_FILE" \
   || echo "WARN: could not append the implementer-proposal block — this run reports only."
 
@@ -214,7 +222,14 @@ ln -sf "$(basename "$DIGEST")" "$REVIEW_DIR/LATEST.md"
 
 VERDICT="$(head -1 "$DIGEST" | sed 's/^VERDICT:[[:space:]]*//')"
 [ -n "$VERDICT" ] || VERDICT="Digest written (no verdict line found)"
-report_out "WhisperShortcut growth review — $VERDICT" "$DIGEST"
+# The subject is the job and the date, not the finding. The finding used to lead it and ran to 120
+# characters, which pushed the one thing a phone notification has to show — whether this needs you —
+# past where every mail client truncates. It still leads the mail itself ("In one line:"), and the
+# notification below still speaks it.
+report_out "WhisperShortcut growth review ($STAMP)" "$DIGEST" \
+  --verdict proposals --proposals-file "$IMPLEMENTER_PROPOSAL_FILE" \
+  --title "Growth review $STAMP" \
+  --meta "Job=growth-review (biweekly)" --meta "Digest=$DIGEST"
 notify "WhisperShortcut growth review" "$VERDICT"
 echo "VERDICT: $VERDICT"
 echo "Digest: $DIGEST"

--- a/scripts/implementer/groom-queue.py
+++ b/scripts/implementer/groom-queue.py
@@ -195,7 +195,11 @@ def load_proposals(paths):
     return out
 
 
-def send_mail(subject, body, no_mail=False):
+def send_mail(subject, body, no_mail=False, verdict_args=()):
+    """`verdict_args` are send-report-mail.py flags stating whether the operator has to act —
+    the banner at the top of the mail (scripts/operator_mail.py). A groom mail that announces a
+    veto window and one that only reports a promotion look alike in prose and are opposites in
+    what they ask of the reader."""
     if no_mail:
         log("--no-mail: NOT sending the announcement below. This is a test run only.")
         log(f"  subject: {subject}")
@@ -208,7 +212,8 @@ def send_mail(subject, body, no_mail=False):
         fh.write(body)
     try:
         rc = subprocess.run(
-            [sys.executable, helper, "--to", MAIL_TO, "--subject", subject, "--body-file", tmp]
+            [sys.executable, helper, "--to", MAIL_TO, "--subject", subject, "--body-file", tmp,
+             "--title", "Implementer queue groomed", *verdict_args]
         ).returncode
         if rc != 0:
             # A VETO row that is never announced is not a veto window — it is an unattended
@@ -364,11 +369,39 @@ def main():
                 "",
             ]
         lines.append("Queue: plans/implementer-queue.md")
+        # Two different mails wear this subject. One opened veto windows — that is a deadline
+        # the operator can act on, and the only state in the vocabulary that says "your silence
+        # decides". The other only reports rows the clock already promoted, which is a record of
+        # something that happened and needs a green banner, not an amber one.
+        open_windows = [(n, d) for n, _, d, _ in announcements] + [(n, d) for n, _, d in released]
+        if open_windows:
+            soonest = min(d for _, d in open_windows)
+            verdict_args = [
+                "--verdict", "ships-on-silence",
+                "--verdict-detail",
+                f"{len(open_windows)} queue row"
+                f"{'' if len(open_windows) == 1 else 's'} now build unattended, the first on "
+                f"{soonest}. Each passed class, scope, falsifier and duplicate checks, and each is "
+                "reversible; when one builds you get its own mail with a two-day merge window "
+                "before anything reaches main.",
+                "--verdict-stop-with",
+                "bash scripts/implementer/veto.sh <#> — the numbers are below.",
+            ]
+        else:
+            verdict_args = [
+                "--verdict", "handled",
+                "--verdict-handler", "the hourly tick",
+                "--verdict-detail",
+                f"{len(ripe)} row{'' if len(ripe) == 1 else 's'} reached the end of a veto window "
+                "you did not stop, so they are BUILD now and the next hourly tick starts the "
+                "topmost one. You will get a mail per build, each with its own merge window.",
+            ]
         send_mail(
             f"WhisperShortcut implementer — {len(announcements) + len(released)} to veto, "
             f"{len(ripe)} promoted",
             "\n".join(lines),
             no_mail=args.no_mail,
+            verdict_args=verdict_args,
         )
 
     # Commit on main: a proposal filed on a branch nobody merges is a proposal nobody sees.

--- a/scripts/implementer/health-report.py
+++ b/scripts/implementer/health-report.py
@@ -223,7 +223,33 @@ def build_body(rows):
     on_a_clock = len(veto) + len([w for w in windows if not w.get("VETOED")])
     subject = (f"WhisperShortcut implementer — {on_a_clock} on a clock, {len(ask)} on your desk, "
                f"{len(parked)} parked")
-    return subject, "\n".join(lines)
+
+    # The verdict states which of those three numbers the reader is actually being asked about.
+    # ASK/OPEN is the only one that is his: DEFERRED waits for a slot, BLOCKED for a scope
+    # decision he makes once for all of them, DEFECT for the loop that wrote the row. Ranking
+    # them by loudness rather than reporting all three is the whole point — this mail exists
+    # because a lane that says everything says nothing.
+    if ask:
+        verdict = ["--verdict", "needs-decision", "--verdict-count", str(len(ask)),
+                   "--verdict-detail",
+                   "They are under \"Waiting on you\" below. Nothing else in this lane is: the "
+                   "machine cannot rule on them, so they sit until you do — release one with "
+                   "keep.sh or leave it. Everything else on this list is on a clock or waiting "
+                   "for a build slot."]
+    elif on_a_clock:
+        verdict = ["--verdict", "ships-on-silence",
+                   "--verdict-detail",
+                   f"{on_a_clock} row{'' if on_a_clock == 1 else 's'} build or merge on their own "
+                   "deadline, listed at the top with their dates. Nothing here is waiting for a "
+                   "decision from you.",
+                   "--verdict-stop-with", "bash scripts/implementer/veto.sh <#>"]
+    else:
+        verdict = ["--verdict", "fyi",
+                   "--verdict-detail",
+                   "Nothing in the lane is waiting for you and nothing is on a clock. This mail "
+                   "arrives weekly whatever the queue says, because a lane that has gone quiet "
+                   "and a lane with nothing to do are indistinguishable from silence."]
+    return subject, "\n".join(lines), verdict
 
 
 def main():
@@ -242,7 +268,7 @@ def main():
     except OSError as exc:
         print(f"cannot read the queue at {args.queue_file}: {exc}", file=sys.stderr)
         return 1
-    subject, body = build_body(rows_from(text))
+    subject, body, verdict = build_body(rows_from(text))
 
     if args.dry_run:
         print(subject)
@@ -256,7 +282,8 @@ def main():
     try:
         rc = subprocess.run(
             [sys.executable, os.path.join(REPO_ROOT, "scripts", "send-report-mail.py"),
-             "--to", MAIL_TO, "--subject", subject, "--body-file", tmp]
+             "--to", MAIL_TO, "--subject", subject, "--body-file", tmp,
+             "--title", "Implementer machine health", *verdict]
         ).returncode
     finally:
         os.unlink(tmp)

--- a/scripts/implementer/proposal-prompt.sh
+++ b/scripts/implementer/proposal-prompt.sh
@@ -3,15 +3,27 @@
 # readable proposal file next to its prose report.
 #
 #     bash scripts/implementer/proposal-prompt.sh <loop-name> >> "$PROMPT_FILE"
+#     bash scripts/implementer/proposal-prompt.sh <loop-name> --path-only   # just the JSON path
+#
+# `--path-only` exists so the caller can count what the run actually proposed: the job's mail has to
+# say whether anything reached the implementer queue, and "proposed nothing" and "wrote its file
+# under a name nobody looked for" must not read alike. Export the printed path as
+# IMPLEMENTER_PROPOSAL_FILE and the prompt below tells the run to write exactly there.
 #
 # Why a sidecar rather than parsing the reports: the groomer must contain no judgement
 # (scripts/implementer/groom-queue.py), and a parser guessing which paragraph of a monthly audit
 # is a proposal is exactly that. The loop already knows what it is proposing — it just has to
 # say so in a form a lookup table can read. One place to maintain the schema; four callers.
 set -euo pipefail
-LOOP="${1:?usage: proposal-prompt.sh <loop-name>}"
+LOOP="${1:?usage: proposal-prompt.sh <loop-name> [--path-only]}"
 INCOMING="${IMPLEMENTER_INCOMING_DIR:-$HOME/.local/state/whispershortcut-implementer/incoming}"
 mkdir -p "$INCOMING"
+PROPOSAL_FILE="${IMPLEMENTER_PROPOSAL_FILE:-${INCOMING}/${LOOP}-$(date +%Y-%m-%d-%H%M%S).json}"
+
+if [ "${2:-}" = "--path-only" ]; then
+  echo "$PROPOSAL_FILE"
+  exit 0
+fi
 
 cat <<EOF
 
@@ -19,7 +31,7 @@ cat <<EOF
 
 Besides the report above, write a JSON file to:
 
-    ${INCOMING}/${LOOP}-$(date +%Y-%m-%d-%H%M%S).json
+    ${PROPOSAL_FILE}
 
 It holds a LIST of the proposals from this run that are concrete enough to build — usually 0 to
 3, and **an empty list \`[]\` is the right answer whenever this run's honest verdict is "build

--- a/scripts/implementer/release-merges.sh
+++ b/scripts/implementer/release-merges.sh
@@ -53,9 +53,12 @@ PUSH_MAIN="${IMPLEMENTER_AUTO_PUSH_MAIN:-1}"
 # change and needs the same deliberate act as widening AUTO_CLASSES.
 REGATE_EXEMPT_REGEX='^(plans/|\.cursor/|\.agents/|[^/]+\.md$)'
 
-mail_out() { # mail_out <subject> <body-file>
-    python3 "${REPO_ROOT}/scripts/send-report-mail.py" --to "$MAIL_TO" --subject "$1" --body-file "$2" \
-        || warn "could not send mail — see ${2}"
+mail_out() { # mail_out <subject> <body-file> [send-report-mail.py flags …]
+    # Every call states a verdict — this lane's mails are mostly "it landed, do nothing", and the
+    # one that needs a hand has to be distinguishable from them at a glance, not by reading.
+    local subject="$1" body="$2"; shift 2
+    python3 "${REPO_ROOT}/scripts/send-report-mail.py" --to "$MAIL_TO" --subject "$subject" --body-file "$body" "$@" \
+        || warn "could not send mail — see ${body}"
 }
 notify() {
     osascript -e "display notification \"$(printf '%s' "$2" | sed 's/"/\\"/g')\" with title \"$1\"" >/dev/null 2>&1 || true
@@ -170,7 +173,11 @@ Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
             echo "Merge it yourself:  git -C ${REPO_ROOT} merge --ff-only ${BRANCH}"
             echo "Drop it:            git -C ${REPO_ROOT} worktree remove --force ${WT_DIR} && git -C ${REPO_ROOT} branch -D ${BRANCH}"
         } >"$note"
-        mail_out "WhisperShortcut implementer — merge #${QUEUE_NUM} stopped" "$note"
+        mail_out "WhisperShortcut implementer — merge #${QUEUE_NUM} stopped" "$note" \
+            --verdict fyi --verdict-detail "You stopped this window with veto.sh, and it is now \
+closed. The branch and its worktree are kept and the queue row is ASK, so no tick rebuilds it — \
+nothing further happens to it unless you merge or drop it yourself (commands below)." \
+            --title "Merge window stopped — queue #${QUEUE_NUM}"
         rm -f "$note"
         return
     fi
@@ -240,7 +247,11 @@ Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
                 echo "Branch ${BRANCH} could not be rebased onto main. Worktree kept: ${WT_DIR}"
                 echo "The queue row is ASK, so nothing rebuilds it."
             } >"$cnote"
-            mail_out "WhisperShortcut implementer — #${QUEUE_NUM} rebase conflict" "$cnote"
+            mail_out "WhisperShortcut implementer — #${QUEUE_NUM} rebase conflict" "$cnote" \
+                --verdict needs-fix --verdict-detail "The branch could not be rebased onto main \
+and resolving a conflict is not something this pipeline claims to do. The row is ASK, so nothing \
+retries it: the change stays unmerged until you resolve it by hand." \
+                --title "Rebase conflict — queue #${QUEUE_NUM}"
             rm -f "$cnote"
             return
         fi
@@ -326,7 +337,12 @@ Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
         echo
         echo "Undo it:  git -C ${REPO_ROOT} revert --no-commit ${main_before}..HEAD"
     } >"$note"
-    mail_out "WhisperShortcut implementer MERGED (#${QUEUE_NUM})" "$note"
+    mail_out "WhisperShortcut implementer MERGED (#${QUEUE_NUM})" "$note" \
+        --verdict fyi --verdict-detail "The merge window ran out and the change is on main. \
+Merging is not releasing: the parent repo's submodule pointer, create-release.sh and the App \
+Store submission are all still yours, so nothing has reached a user. The revert command is at \
+the end of the report." \
+        --title "Merged to main — queue #${QUEUE_NUM}"
     notify "WhisperShortcut implementer MERGED" "Queue #${QUEUE_NUM} is on main"
     rm -f "$note"
     log "═══ MERGED ═══  queue #${QUEUE_NUM} is on main (${gates_note})."

--- a/scripts/implementer/run-implementer.sh
+++ b/scripts/implementer/run-implementer.sh
@@ -135,6 +135,9 @@ alert_and_die() { # alert_and_die <subject> <body>
     local body_file; body_file="$(mktemp -t implementer-preflight)"
     printf '%s\n' "$2" >"$body_file"
     python3 "${REPO_ROOT}/scripts/send-report-mail.py" --to "$MAIL_TO" --subject "$1" --body-file "$body_file" \
+        --verdict needs-fix --verdict-detail "The implementer cannot run at all until this is fixed. \
+No later tick works around it: every hourly tick from now on stops here, so the queue stops moving \
+and its silence will look like an empty queue." \
         >/dev/null 2>&1 || warn "could not send mail — body kept at ${body_file}"
     die "$1"
 }
@@ -243,9 +246,12 @@ log "monthly budget: run $((RUNS_THIS_MONTH + 1)) of ${MAX_RUNS_PER_MONTH}"
 notify() {
     osascript -e "display notification \"$(printf '%s' "$2" | sed 's/"/\\"/g')\" with title \"$1\"" >/dev/null 2>&1 || true
 }
-report_out() { # report_out <subject> <body-file>
-    python3 "${REPO_ROOT}/scripts/send-report-mail.py" --to "$MAIL_TO" --subject "$1" --body-file "$2" \
-        || warn "could not send mail — see ${2}"
+report_out() { # report_out <subject> <body-file> [send-report-mail.py flags …]
+    # Every call states a verdict — the banner at the top of the mail is what answers "muss ich
+    # hier etwas tun?" for a lane whose whole point is that most of its mails need nothing.
+    local subject="$1" body="$2"; shift 2
+    python3 "${REPO_ROOT}/scripts/send-report-mail.py" --to "$MAIL_TO" --subject "$subject" --body-file "$body" "$@" \
+        || warn "could not send mail — see ${body}"
 }
 
 # The test gate below kills the app. Remember whether it was running, so we can put the user's
@@ -299,7 +305,12 @@ fail_run() { # fail_run <reason>
         echo "Worktree kept: ${WT_DIR}"
         echo "Logs: ${RUN_DIR}"
     } >"$note"
-    report_out "WhisperShortcut implementer FAILED (#${Q_NUM})" "$note"
+    report_out "WhisperShortcut implementer FAILED (#${Q_NUM})" "$note" \
+        --verdict needs-fix --verdict-detail "Queue row #${Q_NUM} did not build. Its row stays \
+eligible, so the next hourly tick will try the same row again and can fail the same way; the \
+worktree and logs are kept for the post-mortem (paths below)." \
+        --title "Implementer FAILED — queue #${Q_NUM}" \
+        --meta "Queue row=#${Q_NUM}" --meta "Branch=${BRANCH}" --meta "Logs=${RUN_DIR}"
     notify "WhisperShortcut implementer FAILED" "$1"
     exit 1
 }
@@ -848,9 +859,21 @@ launch_branch_build
     echo "the automation's own falsifier is graded from that column."
 } >"$REPORT"
 
-SUBJECT_TAIL=""
-[[ -n "$MERGE_DEADLINE" ]] && SUBJECT_TAIL=" — merges ${MERGE_DEADLINE} unless stopped"
-report_out "WhisperShortcut implementer READY — #${Q_NUM} ${Q_PROPOSAL:0:60}${SUBJECT_TAIL}" "$REPORT"
+# The verdict is the merge window, not the build: a run that opened one needs nothing from you
+# and says so with its deadline; a run that did not (IMPLEMENTER_AUTO_MERGE=0) is a branch that
+# sits there until you merge it, which is a decision and must not wear a green banner.
+READY_VERDICT=(--verdict needs-decision --verdict-count 1
+    --verdict-detail "Queue row #${Q_NUM} built and passed every gate, but no merge window was opened (IMPLEMENTER_AUTO_MERGE=0), so this branch merges only when you merge it. Nothing else moves it.")
+if [[ -n "$MERGE_DEADLINE" ]]; then
+    READY_VERDICT=(--verdict ships-on-silence
+        --verdict-detail "Queue row #${Q_NUM} built and passed every gate. It merges into main on ${MERGE_DEADLINE}; the branch build is yours to try until then."
+        --verdict-stop-with "cd ${REPO_ROOT} && bash scripts/implementer/veto.sh ${Q_NUM} (keeps the branch — it closes the window, it does not reject the change).")
+fi
+report_out "WhisperShortcut implementer READY — #${Q_NUM} ${Q_PROPOSAL:0:60}" "$REPORT" \
+    "${READY_VERDICT[@]}" \
+    --title "Implementer READY — queue #${Q_NUM}" \
+    --meta "Queue row=#${Q_NUM}" --meta "Branch=${BRANCH}" \
+    --meta "Review=${REVIEW_VERDICT}" --meta "Files changed=${FILE_COUNT}"
 if [[ "$BRANCH_BUILD_RUNNING" == "1" ]]; then
     notify "WhisperShortcut implementer READY" "Queue #${Q_NUM} is now RUNNING as ${BRANCH} — try it"
 else

--- a/scripts/implementer/tick.sh
+++ b/scripts/implementer/tick.sh
@@ -243,6 +243,12 @@ if [[ "$CURRENT_BRANCH" != "main" ]]; then
         } >"$NOTE"
         python3 "${REPO_ROOT}/scripts/send-report-mail.py" --to "${AUDIT_MAIL_TO:-mail@magnus-goedde.de}" \
             --subject "WhisperShortcut implementer builds paused (${BLOCKED_HOURS}h)" --body-file "$NOTE" \
+            --verdict needs-fix --verdict-detail "The build lane has been stopped for ${BLOCKED_HOURS}h \
+because the shared checkout is on '${CURRENT_BRANCH}' instead of main, and no tick works around that: \
+it will stay stopped, silently looking like an empty queue, until you switch the checkout back \
+(command below). Grooming is unaffected — proposals are still filed and veto windows still promote." \
+            --title "Implementer builds paused" \
+            --meta "Blocked for=${BLOCKED_HOURS}h" --meta "Checkout is on=${CURRENT_BRANCH}" \
             || osascript -e "display notification \"on branch ${CURRENT_BRANCH} for ${BLOCKED_HOURS}h\" with title \"Implementer builds paused\"" >/dev/null 2>&1
         rm -f "$NOTE"
     fi

--- a/scripts/model-audit-job.sh
+++ b/scripts/model-audit-job.sh
@@ -176,6 +176,11 @@ EOF
 # a ledger row nobody flags. The schema lives in one place, not four:
 # scripts/implementer/proposal-prompt.sh. Appending is best-effort — a loop whose report is
 # written must not fail because the sidecar prompt could not be generated.
+# The path is fixed here rather than left to the helper's clock, because this run's mail has to
+# say whether anything reached the implementer queue — and "proposed nothing" must not look like
+# "wrote its file under a name nobody counted".
+IMPLEMENTER_PROPOSAL_FILE="$(bash "$REPO/scripts/implementer/proposal-prompt.sh" model-audit --path-only)"
+export IMPLEMENTER_PROPOSAL_FILE
 bash "$REPO/scripts/implementer/proposal-prompt.sh" model-audit >>"$PROMPT_FILE" \
   || echo "WARN: could not append the implementer-proposal block — this run reports only."
 
@@ -194,13 +199,14 @@ notify() {
     >/dev/null 2>&1 || true
 }
 
-# report_out <subject> <body-file> [attachment …] — mail it, notify locally if that fails.
+# report_out <subject> <body-file> [send-report-mail.py flags …] — mail it, notify locally if that
+# fails. Every call passes a --verdict: the banner at the top of the mail is what answers "muss ich
+# hier etwas tun?", and a mail that leaves it out flags itself as unanswered. Attachments are now
+# explicit --attach flags rather than trailing words, so the two kinds of argument cannot blur.
 report_out() {
   local subject="$1" body="$2"; shift 2
-  local attach_args=()
-  for a in "$@"; do attach_args+=(--attach "$a"); done
   if python3 "$REPO/scripts/send-report-mail.py" --to "$AUDIT_MAIL_TO" \
-       --subject "$subject" --body-file "$body" "${attach_args[@]+"${attach_args[@]}"}"; then
+       --subject "$subject" --body-file "$body" "$@"; then
     return 0
   fi
   echo "WARN: could not send mail — falling back to a local notification"
@@ -228,7 +234,11 @@ if [ $STATUS -ne 0 ] || [ ! -f "$REPORT" ]; then
     echo "The measurements did run and are attached. Log: $REPO/build/logs/model-audit.log"
     echo "Re-run manually with: bash scripts/model-audit-job.sh"
   } > "$FAIL_NOTE"
-  report_out "WhisperShortcut model audit FAILED ($STAMP)" "$FAIL_NOTE" "$RAW"
+  report_out "WhisperShortcut model audit FAILED ($STAMP)" "$FAIL_NOTE" --attach "$RAW" \
+    --verdict needs-fix --verdict-detail "The judging pass did not finish, so this month has \
+no model recommendation and no proposal reached the implementer queue. The measurements did \
+run and are attached. Nothing retries it — the next scheduled run is a month away unless you \
+re-run it by hand (command below)."
   rm -f "$FAIL_NOTE"
   exit 1
 fi
@@ -240,7 +250,15 @@ VERDICT="$(head -1 "$REPORT" | sed 's/^VERDICT:[[:space:]]*//')"
 [ -n "$VERDICT" ] || VERDICT="Report written (no verdict line found)"
 # The verdict goes in the subject so it is readable from a phone lock screen without opening
 # the mail; the report is the body, the raw measurements are attached for anything questionable.
-report_out "WhisperShortcut model audit — $VERDICT" "$REPORT" "$RAW"
+# The subject is the job and the date, not the finding. The finding used to lead it and ran to 120
+# characters, which pushed the one thing a phone notification has to show — whether this needs you —
+# past where every mail client truncates. It still leads the mail itself ("In one line:"), and the
+# notification below still speaks it.
+report_out "WhisperShortcut model audit ($STAMP)" "$REPORT" --attach "$RAW" \
+  --verdict proposals --proposals-file "$IMPLEMENTER_PROPOSAL_FILE" \
+  --title "Model audit $STAMP" \
+  --meta "Job=model-audit (monthly)" --meta "Report=$REPORT" \
+  --meta "Raw measurements=attached"
 echo "VERDICT: $VERDICT"
 echo "Report: $REPORT"
 echo "=== Model audit finished: $(date '+%Y-%m-%d %H:%M:%S') ==="

--- a/scripts/operator_mail.py
+++ b/scripts/operator_mail.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""One vocabulary for the question every job mail is opened with: **muss ich hier etwas tun?**
+
+Ported from sabaki.dance's `apps/shared/operator-action.ts` and the banner/shell half of
+`apps/shared/html.ts` (2026-09-06, ported here 2026-09-07). The problem it fixes is the same one,
+and this repo had it worse: every scheduled job mails a markdown digest whose first line is a
+`VERDICT:` about the *finding* — "noSpeechDetected is 76% streaming-chunk noise" — and nothing in
+the mail says whether the reader has to act on it. The answer existed: proposals from that run had
+already been groomed into `plans/implementer-queue.md`, one row released to build on silence with a
+deadline two days out, one waiting for a human. None of that was in the mail.
+
+The fix is not better wording per mail — it is the same five words in the same place every time.
+A sender picks a **state**, never a sentence:
+
+    verdict_fyi              ✅ Nothing to do — for your information.
+    verdict_handled_by       ✅ Nothing to do — handled automatically.
+    verdict_ships_on_silence ⏳ Nothing to do unless you disagree.
+    verdict_needs_decision   ⚠️ Needs you: N decisions.
+    verdict_needs_fix        🚨 Needs you: nothing automatic covers this.
+
+`detail` is the only variable part and answers exactly one follow-up: *who* does the thing, and
+*when*. Claiming a handler that does not exist is worse than claiming nothing — every
+`verdict_handled_by` must name a job that is actually armed (the hourly
+`com.whispershortcut.implementer-tick`, the weekly health report, the release sweep).
+
+Rendering lives here too, so the banner looks identical in every mail and is dark-mode-safe in one
+place. `send-report-mail.py` is the only caller that sends; everything else builds a verdict.
+
+Deliberately dependency-free: these mails are sent from launchd jobs on a bare Mac, where the
+system python3 has no markdown library and a failed import means a job that reports nothing.
+"""
+import html as _html
+import json
+import os
+import re
+
+# ---------------------------------------------------------------------------- the vocabulary
+
+_NOTHING_TO_DO = "✅ Nothing to do — for your information."
+_HANDLED = "✅ Nothing to do — handled automatically."
+_SILENCE_IS_YES = "⏳ Nothing to do unless you disagree."
+
+
+class OperatorVerdict:
+    """needs_you drives nothing on its own; severity drives the colour, the rest is text."""
+
+    def __init__(self, needs_you, severity, subject_suffix, headline, detail):
+        self.needs_you = needs_you
+        self.severity = severity          # 'ok' | 'attention' | 'alarm'
+        self.subject_suffix = subject_suffix
+        self.headline = headline
+        self.detail = detail
+
+
+def verdict_fyi(detail):
+    """A record of something that happened. Nobody is going to act on it, including you."""
+    return OperatorVerdict(False, "ok", "FYI", _NOTHING_TO_DO, detail)
+
+
+def verdict_handled_by(handler, detail):
+    """Someone else already has this — a tick, the queue, a sweep. `handler` names it in the
+    operator's words; `detail` says when it runs and what would bring it back to him."""
+    return OperatorVerdict(False, "ok", f"{handler} has it", _HANDLED, detail)
+
+
+def verdict_ships_on_silence(what, stop_with):
+    """The veto pattern: it ships unless he stops it. Not a question — a deadline."""
+    return OperatorVerdict(False, "attention", "ships unless you stop it", _SILENCE_IS_YES,
+                           f"{what} Silence is a yes. To stop it: {stop_with}")
+
+
+def verdict_needs_decision(count, detail):
+    """A judgement no gate can make. `count` is how many, so the subject can say it."""
+    plural = "" if count == 1 else "s"
+    return OperatorVerdict(True, "attention", f"{count} decision{plural} for you",
+                           f"⚠️ Needs you: {count} decision{plural}.", detail)
+
+
+def verdict_needs_fix(detail):
+    """Something is broken and no automation covers it. The loudest state we have."""
+    return OperatorVerdict(True, "alarm", "needs you",
+                           "🚨 Needs you: nothing automatic covers this.", detail)
+
+
+def verdict_unstated():
+    """The sender did not say. Loud on purpose and never silent: a mail that cannot answer the
+    question is the bug this module exists to remove, so it reports itself rather than sending a
+    quiet-looking mail whose sender simply forgot the flag."""
+    return OperatorVerdict(True, "attention", "verdict missing",
+                           "⚠️ This mail did not say whether you have to act.",
+                           "Its sender passed no --verdict to scripts/send-report-mail.py, so read "
+                           "it yourself and fix the sender: scripts/operator_mail.py lists the "
+                           "five states.")
+
+
+def verdict_text(verdict):
+    """Both halves of a mail carry the verdict; the plain-text one is this."""
+    return f"{verdict.headline}\n{verdict.detail}"
+
+
+def with_verdict_subject(subject, verdict):
+    """Subjects read better as `<what> — <verdict>` than the other way round: the mail app
+    truncates the tail, and the first words have to say which mail it is."""
+    return f"{subject} — {verdict.subject_suffix}"
+
+
+# ------------------------------------------------------------- the loops' shared queue verdict
+
+def queue_sentence(count):
+    """What the queue does with a loop's proposals, in the operator's terms. The chain is real and
+    unattended: `$IMPLEMENTER_INCOMING_DIR` → the hourly tick → `groom-queue.py` →
+    `plans/implementer-queue.md` (BUILD builds straight away, VETO builds on silence, ASK waits for
+    him) → `run-implementer.sh`."""
+    return (
+        f"{count} proposal{'' if count == 1 else 's'} went to the implementer queue. "
+        "The hourly tick grooms them into plans/implementer-queue.md and gate-covered ones are "
+        "built unattended; a row it releases on silence is announced with its own deadline mail, "
+        "and anything it cannot justify reaches you in the weekly \"machine health\" mail, never here."
+    )
+
+
+def count_proposals(path):
+    """How many proposals a run actually handed over. Read from the sidecar the loop wrote, or from
+    the groomer's archive when an hourly tick already consumed it — a run whose file was groomed
+    between the pass and the mail proposed exactly as much as one whose file is still there."""
+    if not path:
+        return 0
+    candidates = [path, os.path.join(os.path.dirname(path), "archive", os.path.basename(path))]
+    for candidate in candidates:
+        try:
+            with open(candidate, "r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except (OSError, ValueError):
+            continue
+        if isinstance(data, list):
+            return len(data)
+        return 1 if isinstance(data, dict) and data else 0
+    return 0
+
+
+def verdict_for_proposals(path):
+    """The verdict a finished loop run gets, derived from machine facts rather than from the run's
+    own summary of itself — an agent describing its own run is exactly the thing that drifts."""
+    count = count_proposals(path)
+    if count == 0:
+        return verdict_fyi("This run proposed no code change, so nothing was queued and nothing is "
+                           "waiting on you. The digest is below.")
+    return verdict_handled_by("the implementer queue", queue_sentence(count))
+
+
+# ------------------------------------------------------------------------------- rendering
+
+_VERDICT_PALETTE = {
+    "ok":        {"bg": "#ecfdf5", "accent": "#059669", "heading": "#065f46"},
+    "attention": {"bg": "#fffbeb", "accent": "#d97706", "heading": "#92400e"},
+    "alarm":     {"bg": "#fef2f2", "accent": "#dc2626", "heading": "#991b1b"},
+}
+
+
+def render_banner(verdict):
+    """The banner that opens a job mail. One look, one position, one vocabulary — so the reader
+    answers "do I have to act?" by recognising a colour, not by reading three screens of report.
+
+    The dark palette lives in the document stylesheet under the `verdict-*` classes, because a
+    `<style>` block is the only place a media query can go and inline styles cannot switch theme.
+    """
+    palette = _VERDICT_PALETTE.get(verdict.severity, _VERDICT_PALETTE["attention"])
+    return (
+        f'<div class="verdict-card verdict-{verdict.severity}" style="background-color:{palette["bg"]};'
+        f'border-left:4px solid {palette["accent"]};border-radius:8px;padding:16px 18px;margin:0 0 20px 0;">'
+        f'<div class="verdict-headline" style="color:{palette["heading"]};font-size:17px;'
+        f'font-weight:bold;line-height:1.35;">{_html.escape(verdict.headline)}</div>'
+        f'<div class="verdict-detail" style="color:#4b5563;font-size:14px;line-height:1.55;'
+        f'margin-top:8px;">{_linkify(_html.escape(verdict.detail))}</div>'
+        f"</div>"
+    )
+
+
+_URL_RE = re.compile(r"(?<![\"'=])\bhttps?://[^\s<>\")]+")
+
+
+def _linkify(escaped):
+    """Bare URLs in already-escaped text. Report bodies carry PR links and `gh` URLs that are worth
+    a tap on a phone."""
+    return _URL_RE.sub(lambda m: f'<a href="{m.group(0)}">{m.group(0)}</a>', escaped)
+
+
+_INLINE_CODE_RE = re.compile(r"`([^`]+)`")
+_BOLD_RE = re.compile(r"\*\*([^*]+)\*\*")
+_ITALIC_RE = re.compile(r"(?<![*\w])\*([^*\n]+)\*(?!\*)")
+_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)\s]+)\)")
+
+
+def _inline(text):
+    """Markdown's inline subset, on escaped text. Code first: a backticked span is the one place a
+    report writes `**` or `_` and means the characters."""
+    out = _html.escape(text)
+    spans = []
+
+    def stash(markup):
+        spans.append(markup)
+        return f"\x00{len(spans) - 1}\x00"
+
+    out = _INLINE_CODE_RE.sub(lambda m: stash(f"<code>{m.group(1)}</code>"), out)
+    out = _LINK_RE.sub(lambda m: stash(f'<a href="{m.group(2)}">{m.group(1)}</a>'), out)
+    out = _BOLD_RE.sub(r"<strong>\1</strong>", out)
+    out = _ITALIC_RE.sub(r"<em>\1</em>", out)
+    out = _linkify(out)
+    return re.sub(r"\x00(\d+)\x00", lambda m: spans[int(m.group(1))], out)
+
+
+def _render_table(rows):
+    head, body = rows[0], rows[2:]          # rows[1] is the |---|---| separator
+    cells = lambda row, tag: "".join(f"<{tag}>{_inline(c)}</{tag}>" for c in row)
+    body_html = "".join(f"<tr>{cells(r, 'td')}</tr>" for r in body)
+    return f"<table><thead><tr>{cells(head, 'th')}</tr></thead><tbody>{body_html}</tbody></table>"
+
+
+def _split_row(line):
+    return [c.strip() for c in re.split(r"(?<!\\)\|", line.strip().strip("|"))]
+
+
+def markdown_to_html(markdown):
+    """The markdown subset the job reports actually use: headings, tables, lists, fenced code,
+    blockquotes, rules, paragraphs. Not a general parser — a general parser is a dependency, and
+    these mails are sent by launchd from a Mac whose python3 has none."""
+    lines = markdown.replace("\r\n", "\n").split("\n")
+    out, i = [], 0
+    while i < len(lines):
+        line = lines[i]
+
+        if line.strip().startswith("```"):
+            i += 1
+            block = []
+            while i < len(lines) and not lines[i].strip().startswith("```"):
+                block.append(lines[i])
+                i += 1
+            i += 1
+            out.append(f"<pre><code>{_html.escape(chr(10).join(block))}</code></pre>")
+            continue
+
+        if re.match(r"^\s*(?:[-*_]\s*){3,}$", line):
+            out.append("<hr>")
+            i += 1
+            continue
+
+        heading = re.match(r"^(#{1,6})\s+(.*)$", line)
+        if heading:
+            level = min(len(heading.group(1)), 3)
+            out.append(f"<h{level}>{_inline(heading.group(2).strip())}</h{level}>")
+            i += 1
+            continue
+
+        # A table needs its |---|---| second line; without it a line of pipes is prose.
+        if line.strip().startswith("|") and i + 1 < len(lines) and re.match(
+                r"^\s*\|?[\s:|-]+\|[\s:|-]*$", lines[i + 1]):
+            rows = []
+            while i < len(lines) and lines[i].strip().startswith("|"):
+                rows.append(_split_row(lines[i]))
+                i += 1
+            out.append(_render_table(rows))
+            continue
+
+        if re.match(r"^\s*(?:[-*+]|\d+[.)])\s+", line):
+            ordered = bool(re.match(r"^\s*\d+[.)]\s+", line))
+            items = []
+            while i < len(lines) and re.match(r"^\s*(?:[-*+]|\d+[.)])\s+", lines[i]):
+                item = re.sub(r"^\s*(?:[-*+]|\d+[.)])\s+", "", lines[i])
+                i += 1
+                # A wrapped bullet continues on an indented line with no marker of its own.
+                while i < len(lines) and lines[i].strip() and lines[i].startswith((" ", "\t")) \
+                        and not re.match(r"^\s*(?:[-*+]|\d+[.)])\s+", lines[i]):
+                    item += " " + lines[i].strip()
+                    i += 1
+                items.append(f"<li>{_inline(item)}</li>")
+            tag = "ol" if ordered else "ul"
+            out.append(f"<{tag}>{''.join(items)}</{tag}>")
+            continue
+
+        if line.strip().startswith(">"):
+            quote = []
+            while i < len(lines) and lines[i].strip().startswith(">"):
+                quote.append(re.sub(r"^\s*>\s?", "", lines[i]))
+                i += 1
+            out.append(f"<blockquote>{_inline(' '.join(quote))}</blockquote>")
+            continue
+
+        if not line.strip():
+            i += 1
+            continue
+
+        paragraph = []
+        while i < len(lines) and lines[i].strip() and not re.match(
+                r"^\s*(?:#{1,6}\s|[-*+]\s|\d+[.)]\s|>|\||```)", lines[i]):
+            paragraph.append(lines[i].strip())
+            i += 1
+        out.append(f"<p>{_inline(' '.join(paragraph))}</p>")
+
+    return "\n".join(out)
+
+
+def relabel_run_verdict(body):
+    """The digests open with `VERDICT: <one line about the finding>`, and the jobs read that line
+    back for the subject and the notification — so it stays on disk. In the mail it now sits under
+    the operator banner, where two lines both called "verdict" answer two different questions, and
+    the reader has to work out which one is about him. Same sentence, plain label."""
+    lines = body.split("\n")
+    if not lines or not lines[0].startswith("VERDICT:"):
+        return body
+    lines[0] = f"**In one line:** {lines[0][len('VERDICT:'):].strip()}"
+    return "\n".join(lines)
+
+
+def render_document(title, verdict, body_markdown, meta_rows=()):
+    """The one HTML document every job mail is delivered inside.
+
+    Everything here exists because the mail is read on a phone first: a real `<html><head>` with a
+    viewport (without it a phone lays the body out at desktop width and zooms out), and
+    `color-scheme: light dark` so a dark-mode client is told this mail carries its own dark palette
+    and must not run its own inversion over it — which is what turns a green card's text grey.
+    """
+    meta_html = ""
+    if meta_rows:
+        cells = "".join(
+            f'<tr><td class="meta-label" style="color:#6b7280;padding:2px 16px 2px 0;'
+            f'white-space:nowrap;">{_html.escape(str(k))}</td>'
+            f'<td class="meta-value" style="padding:2px 0;"><strong>{_html.escape(str(v))}</strong></td></tr>'
+            for k, v in meta_rows)
+        meta_html = (
+            f'<table style="margin-bottom:8px;font-size:14px;border-collapse:collapse;">{cells}</table>'
+            '<hr class="meta-rule" style="border:none;border-top:1px solid #e5e7eb;margin:16px 0 20px;">')
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
+<title>{_html.escape(title)}</title>
+<style>
+  body {{ margin:0; padding:0; width:100% !important; -webkit-text-size-adjust:100%; }}
+  a {{ color:#2563eb; }}
+  .wrap {{ background-color:#f3f4f6; padding:16px; }}
+  .card {{ background-color:#ffffff; border-radius:12px; padding:24px; max-width:720px; margin:0 auto; }}
+  .h1 {{ color:#2563eb; margin:0 0 20px 0; font-size:22px; line-height:1.3; font-weight:bold; }}
+  .md {{ color:#374151; font-size:14px; line-height:1.55; overflow-wrap:break-word; }}
+  .md h1 {{ font-size:20px; margin:24px 0 12px; color:#111827; }}
+  .md h2 {{ font-size:17px; margin:20px 0 10px; color:#1f2937; border-bottom:1px solid #e5e7eb; padding-bottom:4px; }}
+  .md h3 {{ font-size:15px; margin:16px 0 8px; color:#374151; }}
+  .md p {{ margin:8px 0; }}
+  .md ul, .md ol {{ margin:8px 0 8px 20px; padding:0; }}
+  .md li {{ margin:4px 0; }}
+  .md hr {{ border:none; border-top:1px solid #e5e7eb; margin:20px 0; }}
+  .md table {{ border-collapse:collapse; width:100%; margin:12px 0; font-size:13px; }}
+  .md th, .md td {{ border:1px solid #d1d5db; padding:6px 8px; text-align:left; vertical-align:top; }}
+  .md th {{ background:#f3f4f6; font-weight:600; }}
+  .md code {{ font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:12px; background:#f3f4f6; padding:1px 4px; border-radius:3px; }}
+  .md pre {{ background:#f3f4f6; border:1px solid #e5e7eb; border-radius:6px; padding:12px; overflow-x:auto; font-size:12px; line-height:1.45; }}
+  .md pre code {{ background:none; padding:0; }}
+  .md a {{ color:#2563eb; overflow-wrap:anywhere; }}
+  .md blockquote {{ margin:12px 0; padding-left:12px; border-left:3px solid #d1d5db; color:#6b7280; }}
+  @media only screen and (max-width:480px) {{
+    .wrap {{ padding:8px !important; }}
+    .card {{ padding:18px 16px !important; border-radius:10px !important; }}
+  }}
+  @media (prefers-color-scheme: dark) {{
+    body, .wrap {{ background-color:#0b0f19 !important; }}
+    .card {{ background-color:#161b26 !important; }}
+    .h1 {{ color:#93c5fd !important; }}
+    .meta-label {{ color:#9ca3af !important; }}
+    .meta-value, .meta-value strong {{ color:#e5e7eb !important; }}
+    .meta-rule {{ border-top-color:#374151 !important; }}
+    .md {{ color:#e5e7eb !important; }}
+    .md h1, .md h2, .md h3 {{ color:#f9fafb !important; }}
+    .md h2 {{ border-bottom-color:#374151 !important; }}
+    .md hr {{ border-top-color:#374151 !important; }}
+    .md th, .md td {{ color:#e5e7eb !important; border-color:#374151 !important; }}
+    .md th {{ background:#26303f !important; }}
+    .md code {{ background:#26303f !important; color:#e5e7eb !important; }}
+    .md pre {{ background:#26303f !important; border-color:#374151 !important; color:#e5e7eb !important; }}
+    .md a {{ color:#93c5fd !important; }}
+    .md blockquote {{ border-left-color:#4b5563 !important; color:#9ca3af !important; }}
+    /* The verdict banner's light palette is inline on the element, so the dark one has to be
+       spelled out or the mail's most important line is the one that goes unreadable. */
+    .verdict-detail, .verdict-detail a {{ color:#d1d5db !important; }}
+    .verdict-ok {{ background-color:#12251f !important; border-left-color:#34d399 !important; }}
+    .verdict-ok .verdict-headline {{ color:#6ee7b7 !important; }}
+    .verdict-attention {{ background-color:#2a2313 !important; border-left-color:#f59e0b !important; }}
+    .verdict-attention .verdict-headline {{ color:#fcd34d !important; }}
+    .verdict-alarm {{ background-color:#2a1717 !important; border-left-color:#ef4444 !important; }}
+    .verdict-alarm .verdict-headline {{ color:#fca5a5 !important; }}
+    .foot, .foot a {{ color:#9ca3af !important; }}
+    a {{ color:#93c5fd !important; }}
+  }}
+</style>
+</head>
+<body style="margin:0;padding:0;background-color:#f3f4f6;">
+  <div class="wrap" style="background-color:#f3f4f6;padding:16px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+    <div class="card" style="background-color:#ffffff;border-radius:12px;padding:24px;max-width:720px;margin:0 auto;">
+      <h1 class="h1" style="color:#2563eb;margin:0 0 20px 0;font-size:22px;line-height:1.3;">{_html.escape(title)}</h1>
+      {render_banner(verdict)}
+      {meta_html}
+      <div class="md">
+{markdown_to_html(body_markdown)}
+      </div>
+      <div style="margin-top:28px;padding-top:16px;border-top:1px solid #e5e7eb;">
+        <p class="foot" style="color:#9ca3af;margin:0;font-size:12px;">
+          Automatic report from a WhisperShortcut scheduled job. Verdict vocabulary:
+          scripts/operator_mail.py
+        </p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>"""

--- a/scripts/send-report-mail.py
+++ b/scripts/send-report-mail.py
@@ -6,13 +6,30 @@ report its result while an interactive session happens to be running is not a cr
 talks to IONOS SMTP directly and reuses the credentials the MCP launcher already set up
 (~/.cursor/ionos-mail-mcp.sh) — password from the macOS Keychain, never on disk or in argv.
 
-    python3 scripts/send-report-mail.py --subject "..." --body-file report.md [--attach raw.txt]
+    python3 scripts/send-report-mail.py --subject "..." --body-file report.md \
+        --verdict handled --verdict-handler "the implementer queue" --verdict-detail "..." \
+        [--attach raw.txt]
+
+Every mail states, in one banner at the top, whether the reader has to act — the five states and
+the reasoning behind them are in scripts/operator_mail.py. A sender that passes no `--verdict`
+still sends, loudly flagged as unstated: a mail nobody receives is worse than one whose sender
+forgot the flag.
+
+    --verdict fyi                 nothing to do, for information
+    --verdict handled             --verdict-handler names the job that has it
+    --verdict ships-on-silence    --verdict-stop-with gives the exact stop command
+    --verdict needs-decision      --verdict-count says how many
+    --verdict needs-fix           broken, nothing automatic covers it
+    --verdict proposals           derive fyi/handled from --proposals-file (the loop jobs)
 
 Exit codes: 0 sent, 1 could not send (caller should fall back to a local notification —
 the Keychain is unreadable while the Mac is locked, which is a normal condition at 09:17).
 """
 import argparse, os, smtplib, subprocess, sys
 from email.message import EmailMessage
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import operator_mail as om
 
 ACCOUNT = os.environ.get("AUDIT_MAIL_FROM", "mail@magnus-goedde.de")
 KEYCHAIN_SERVICE = os.environ.get("AUDIT_MAIL_KEYCHAIN_SERVICE", "cursor-ionos-mail")
@@ -39,6 +56,29 @@ def keychain_password():
     return out.stdout.strip()
 
 
+def build_verdict(args):
+    """One state per mail, picked by the sender. Anything unstated is reported as unstated rather
+    than guessed: claiming a handler that is not armed is the one failure mode worse than silence."""
+    if args.verdict == "fyi":
+        return om.verdict_fyi(args.verdict_detail or "The report is below.")
+    if args.verdict == "handled":
+        return om.verdict_handled_by(args.verdict_handler or "an automatic job",
+                                     args.verdict_detail or "")
+    if args.verdict == "ships-on-silence":
+        return om.verdict_ships_on_silence(args.verdict_detail or "",
+                                           args.verdict_stop_with or "(no stop command given)")
+    if args.verdict == "needs-decision":
+        return om.verdict_needs_decision(max(1, args.verdict_count), args.verdict_detail or "")
+    if args.verdict == "needs-fix":
+        return om.verdict_needs_fix(args.verdict_detail or "The report is below.")
+    if args.verdict == "proposals":
+        # No path means the job could not say where its proposals went, which is not the same as
+        # "it proposed nothing" — and a green banner is exactly the wrong way to report not knowing.
+        return om.verdict_for_proposals(args.proposals_file) if args.proposals_file \
+            else om.verdict_unstated()
+    return om.verdict_unstated()
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--to", default=os.environ.get("AUDIT_MAIL_TO", "mail@magnus-goedde.de"))
@@ -46,15 +86,51 @@ def main():
     ap.add_argument("--body-file", required=True)
     ap.add_argument("--attach", action="append", default=[],
                     help="file to attach (repeatable); silently skipped if missing")
+    ap.add_argument("--verdict", choices=["fyi", "handled", "ships-on-silence", "needs-decision",
+                                          "needs-fix", "proposals"])
+    ap.add_argument("--verdict-detail", default="", help="who acts on this next, and when")
+    ap.add_argument("--verdict-handler", default="", help="handled: the job that has it")
+    ap.add_argument("--verdict-stop-with", default="", help="ships-on-silence: the stop command")
+    ap.add_argument("--verdict-count", type=int, default=1, help="needs-decision: how many")
+    ap.add_argument("--proposals-file", default="", help="proposals: the loop's sidecar JSON")
+    ap.add_argument("--meta", action="append", default=[], metavar="LABEL=VALUE",
+                    help="a row in the small table above the report (repeatable)")
+    ap.add_argument("--keep-subject", action="store_true",
+                    help="the subject already answers the question — do not append the suffix")
+    ap.add_argument("--title", default="", help="heading inside the mail (default: the subject)")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="print the subject and text half, write the HTML to --html-out, send nothing")
+    ap.add_argument("--html-out", default="", help="also write the rendered HTML here")
     args = ap.parse_args()
 
     if not os.path.exists(args.body_file):
         sys.exit(f"body file not found: {args.body_file}")
     body = open(args.body_file, "rb").read()
     truncated = len(body) > MAX_BODY_BYTES
-    text = body[:MAX_BODY_BYTES].decode("utf-8", "replace")
+    report = body[:MAX_BODY_BYTES].decode("utf-8", "replace")
     if truncated:
-        text += f"\n\n[…truncated at {MAX_BODY_BYTES} bytes — full report: {args.body_file}]"
+        report += f"\n\n[…truncated at {MAX_BODY_BYTES} bytes — full report: {args.body_file}]"
+
+    verdict = build_verdict(args)
+    subject = args.subject if args.keep_subject else om.with_verdict_subject(args.subject, verdict)
+    report = om.relabel_run_verdict(report)
+    meta_rows = [tuple(m.split("=", 1)) for m in args.meta if "=" in m]
+
+    text = "\n".join([om.verdict_text(verdict), ""]
+                     + [f"{k}: {v}" for k, v in meta_rows]
+                     + ([""] if meta_rows else [])
+                     + ["─" * 32, "", report])
+    html = om.render_document(args.title or args.subject, verdict, report, meta_rows)
+
+    if args.html_out:
+        with open(args.html_out, "w", encoding="utf-8") as handle:
+            handle.write(html)
+        print(f"HTML written to {args.html_out}")
+    if args.dry_run:
+        # The text half says nothing about how the mail actually looks, which is where a
+        # dark-mode regression would hide — so --html-out is the half worth opening.
+        print(f"[dry-run] To: {args.to}\n[dry-run] Subject: {subject}\n\n{text}")
+        return 0
 
     password = keychain_password()
     if password is None:
@@ -63,8 +139,9 @@ def main():
     msg = EmailMessage()
     msg["From"] = ACCOUNT
     msg["To"] = args.to
-    msg["Subject"] = args.subject
+    msg["Subject"] = subject
     msg.set_content(text)
+    msg.add_alternative(html, subtype="html")
 
     for path in args.attach:
         if not os.path.exists(path):

--- a/scripts/usage-review-job.sh
+++ b/scripts/usage-review-job.sh
@@ -90,12 +90,15 @@ notify() {
     >/dev/null 2>&1 || true
 }
 
-# report_out <subject> <body-file> — mail it, notify locally if that fails. The Keychain is
+# report_out <subject> <body-file> [send-report-mail.py flags …] — mail it, notify locally if
+# that fails. Every call passes a --verdict: the banner at the top of the mail is what answers
+# "muss ich hier etwas tun?", and a mail that leaves it out flags itself as unanswered.
+# The Keychain is
 # unreadable while the Mac is locked, which at 08:47 on a Monday is a normal condition.
 report_out() {
-  local subject="$1" body="$2"
+  local subject="$1" body="$2"; shift 2
   if python3 "$REPO/scripts/send-report-mail.py" --to "$AUDIT_MAIL_TO" \
-       --subject "$subject" --body-file "$body"; then
+       --subject "$subject" --body-file "$body" "$@"; then
     return 0
   fi
   echo "WARN: could not send mail — falling back to a local notification"
@@ -108,7 +111,10 @@ fail_out() {
   echo "VERDICT: $verdict"   # also to the log — mail and notification can both be unavailable
   local note; note="$(mktemp -t wsreviewfail)"
   { echo "VERDICT: $verdict"; echo; for line in "$@"; do echo "$line"; done; } > "$note"
-  report_out "WhisperShortcut usage review FAILED ($STAMP)" "$note"
+  report_out "WhisperShortcut usage review FAILED ($STAMP)" "$note" \
+    --verdict needs-fix --verdict-detail "$verdict This week produced no proposals, so nothing \
+reached the implementer queue. Nothing retries it — the next scheduled run is a week away, so \
+this week of usage is lost unless you re-run it by hand (command below)."
   notify "WhisperShortcut usage review FAILED" "$verdict"
   rm -f "$note"
   exit 1
@@ -319,6 +325,11 @@ EOF
 # a ledger row nobody flags. The schema lives in one place, not four:
 # scripts/implementer/proposal-prompt.sh. Appending is best-effort — a loop whose report is
 # written must not fail because the sidecar prompt could not be generated.
+# The path is fixed here rather than left to the helper's clock, because this run's mail has to
+# say whether anything reached the implementer queue — and "proposed nothing" must not look like
+# "wrote its file under a name nobody counted".
+IMPLEMENTER_PROPOSAL_FILE="$(bash "$REPO/scripts/implementer/proposal-prompt.sh" usage-review --path-only)"
+export IMPLEMENTER_PROPOSAL_FILE
 bash "$REPO/scripts/implementer/proposal-prompt.sh" usage-review >>"$PROMPT_FILE" \
   || echo "WARN: could not append the implementer-proposal block — this run reports only."
 
@@ -374,7 +385,15 @@ ln -sf "$(basename "$DIGEST")" "$REVIEW_DIR/LATEST.md"
 
 VERDICT="$(head -1 "$DIGEST" | sed 's/^VERDICT:[[:space:]]*//')"
 [ -n "$VERDICT" ] || VERDICT="Digest written (no verdict line found)"
-report_out "WhisperShortcut usage review — $VERDICT" "$DIGEST"
+# The subject is the job and the date, not the finding. The finding used to lead it and ran to 120
+# characters, which pushed the one thing a phone notification has to show — whether this needs you —
+# past where every mail client truncates. It still leads the mail itself ("In one line:"), and the
+# notification below still speaks it.
+report_out "WhisperShortcut usage review ($STAMP)" "$DIGEST" \
+  --verdict proposals --proposals-file "$IMPLEMENTER_PROPOSAL_FILE" \
+  --title "Usage review $STAMP" \
+  --meta "Job=usage-review (weekly)" --meta "Window=last ${DAYS} days" \
+  --meta "Data=$INTERACTIONS interactions, $SIGNALS signals" --meta "Digest=$DIGEST"
 notify "WhisperShortcut usage review" "$VERDICT"
 echo "VERDICT: $VERDICT"
 echo "Digest: $DIGEST"


### PR DESCRIPTION
Ported from sabaki.dance (`apps/shared/operator-action.ts` + the banner/shell half of `apps/shared/html.ts`), where the same problem was fixed on 2026-09-06.

## The problem

Every scheduled job mails a markdown digest whose first line is a `VERDICT:` about the **finding** — "noSpeechDetected is 76% streaming-chunk noise" — and nothing in the mail says whether the reader has to act on it. The answer existed and was nowhere in the mail: the 2026-09-07 usage review's proposals had already been groomed into `plans/implementer-queue.md`, one row released to build on silence with a deadline two days out, one waiting for a human, one filed DEFECT.

## The fix

Not better wording per mail — the same five words in the same place every time. A sender picks a **state**, never a sentence:

| state | reads as |
| ----- | -------- |
| `fyi` | ✅ Nothing to do — for your information. |
| `handled` | ✅ Nothing to do — handled automatically. |
| `ships-on-silence` | ⏳ Nothing to do unless you disagree. |
| `needs-decision` | ⚠️ Needs you: N decisions. |
| `needs-fix` | 🚨 Needs you: nothing automatic covers this. |

- `scripts/operator_mail.py` (new) — the vocabulary, the banner, a dependency-free markdown→HTML pass and the mail document. Dependency-free on purpose: these mails are sent by launchd from a Mac whose python3 has no markdown library, and a failed import is a job that reports nothing.
- `scripts/send-report-mail.py` — gains `--verdict` and friends, and now sends multipart/alternative: the plain-text half opens with the verdict, the HTML half carries the banner card, a metadata table and the rendered report, dark-mode-safe.
- Every sender states one: the four loop jobs, `groom-queue.py`, `run-implementer.sh`, `tick.sh`, `release-merges.sh`, `health-report.py`.

Two properties worth keeping:

- **The verdict comes from machine facts, never from the run's own summary of itself.** The loop jobs derive theirs from the proposal sidecar they actually wrote (`proposal-prompt.sh --path-only` fixes the path so "proposed nothing" cannot look like "wrote its file under a name nobody counted"). `health-report.py` derives its from the queue rows.
- **A sender that forgets the flag still sends**, flagged `⚠️ This mail did not say whether you have to act.` A mail nobody receives is worse than one whose sender forgot the flag.

Also: the duplicate `VERDICT:` line is dropped from the mail body when the subject demonstrably carries it (the digest on disk keeps it — the jobs read that line back), so the banner is the only thing at the top called a verdict.

## Testing

`bash -n` on every touched script; `health-report.py --dry-run` and `send-report-mail.py --dry-run --html-out` against the real 2026-09-07 digest, rendered and checked in light and dark.

Nothing changes until this is on `main` — the launchd jobs run from the main checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
