### PR TITLE
Settle 3.7 vs 3.8 chat latency: the 12% gap was a measurement artefact

### DIFF
--- a/plans/model-audits/2026-09-03-audit.md
+++ b/plans/model-audits/2026-09-03-audit.md
@@ -246,6 +246,12 @@ strictly better on at least one.
   "previous-generation" — the textbook same-price-newer-generation domination. But my own probe
   has 3.8 **~12% slower** (2958 vs 2640 ms median, n=5, ranges overlap). Measurement beats the
   version number: add 3.8, then run a proper interleaved latency comparison before hiding 3.7.
+  **Settled 2026-09-08 — the 12% does not survive that comparison** (`2026-09-08-chat-latency.md`,
+  `scripts/benchmark-chat-latency.py`): the probe above sent a bare `generateContent`, but the app
+  attaches `google_search`/`url_context`/`code_execution` and pins both models to
+  `thinkingLevel: low`. Re-measured interleaved on 12 real prompts × 3 rounds, time to first token
+  is 1603 vs 1752 ms median but 2503 vs 2457 ms **mean**, and 3.7 wins 7 of 12 paired prompts.
+  That is noise. 3.7 stays visible; hiding it needs 3.8 to measure *better*, not merely not worse.
 
 ### Gemini — Flash-Lite tiers
 

--- a/plans/model-audits/2026-09-08-chat-latency.md
+++ b/plans/model-audits/2026-09-08-chat-latency.md
@@ -1,0 +1,81 @@
+# Chat latency: gemini-3.7-flash vs gemini-3.8-flash — settled
+
+The 2026-09-03 audit left exactly one question open about the Chat default. It measured 3.8
+~12% slower than 3.7 (2958 vs 2640 ms, n=5, overlapping ranges) and said, correctly:
+
+> Measurement beats the version number: add 3.8, then run a proper interleaved latency
+> comparison before hiding 3.7.
+
+This is that comparison. Run 2026-09-08 with `scripts/benchmark-chat-latency.py`.
+
+## What the old probe got wrong
+
+Not the arithmetic — the request. The audit's probe sent a bare `generateContent`. The app does
+not:
+
+- `GeminiAPIClient.swift:414` attaches `google_search` + `url_context` + `code_execution` to every
+  chat turn, so a search round-trip lands **before** the first visible word.
+- `PromptModel.geminiThinkingConfig` pins BOTH models to `thinkingLevel: low`
+  (`SettingsConfiguration.swift:587`/`:591`), which the probe did not send.
+
+A latency number measured without those is timing a code path no user reaches. Re-run with them,
+and the gap disappears.
+
+Two further changes, each of which can flip the sign on its own:
+
+- **Interleaved, not batched.** A/B then B/A every round, so a slow minute of the API lands on
+  both models rather than on whichever went second.
+- **Time to first token, not total.** Chat streams into a bubble. Total time is mostly a function
+  of how long an answer the model chose to write — 3.8 writes ~18% more, which is a verbosity
+  difference wearing a speed difference's clothes.
+
+Prompts come from the staged usage log, so the mix is the operator's own: 12 real questions from
+25 to 3776 characters, spanning short factual, tool troubleshooting, opinion and one long paste.
+
+## Result — 12 prompts × 3 rounds × 2 models, time to first token
+
+| Model | Median | Mean | p25 | p75 | Errors |
+|---|---|---|---|---|---|
+| `gemini-3.7-flash` | 1603 ms | 2503 ms | 1046 ms | 2495 ms | 0/36 |
+| `gemini-3.8-flash` | 1752 ms | 2457 ms | 980 ms | 3400 ms | 0/36 |
+
+Paired per prompt: **3.7 faster on 7 of 12, 3.8 on 5.** Median paired delta 292 ms toward 3.7.
+
+Total time favours 3.7 (3526 vs 4263 ms median) but answer length differs in the same direction
+(1472 vs 1730 chars): **per character both are identical, 2.40 vs 2.46 ms**.
+
+**Verdict: the difference is noise.** Means are within 2%, the sign flips depending on which
+statistic you pick, and the per-prompt winner is close to a coin flip. The 12% claim does not
+survive a measurement shaped like the app's own request.
+
+## Quality and screenshots — the axis nothing had measured
+
+5 real prompts plus one screenshot turn (`screenshots/images/chat.png`, "Was sehe ich hier? Wo
+klicke ich, um das Modell zu wechseln?"). Screenshot turns are ~10% of real chat use — 14 of 142
+messages in the 2026-09-07 window carried an image and no text at all.
+
+- **Screenshot: tie.** Both locate the model dropdown bottom-right and additionally name the slash
+  commands. No difference worth a sentence.
+- **Factual: tie.** Both invent *different* Plaud subscription prices ($/€ per month) with
+  grounding enabled, so one of them is wrong. Not an argument either way — but a caution against
+  reading either model's numbers as sourced.
+- **3.8 marginally better on under-specified questions.** Asked "Wenn ich hier auf verschieben
+  drücke…" with no screenshot attached, 3.7 mostly asked back; 3.8 asked back *and* explained what
+  "verschieben" means per platform. At a median question length of 98 characters this is the
+  common case.
+- **3.8 is ~18% more verbose.** Against a median wanted answer of 533 characters, that is a mild
+  negative, not a feature.
+
+## What follows
+
+**No code change.** Do NOT set `gemini37Flash.chatReplacement = .gemini38Flash`: a tie does not
+justify removing a model from the lineup. The condition the 2026-09-03 audit set was "3.8 measures
+better", not "3.8 measures no worse".
+
+`ChatDefaults.selectedChatModel` is already `gemini38Flash`, so fresh installs get the
+current-generation model; an existing selection on 3.7 stays until the user types `/gemini38flash`.
+That asymmetry is deliberate and correct.
+
+**For the next audit:** this question is closed. Re-open it only if Google announces a shutdown
+date for 3.7 (it is filed "previous-generation" today, with no date), or if a measurement using
+`scripts/benchmark-chat-latency.py` shows a gap that survives the paired comparison.

--- a/scripts/benchmark-chat-latency.py
+++ b/scripts/benchmark-chat-latency.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Interleaved chat-latency comparison between two Gemini models, on the operator's own prompts.
+
+The 2026-09-03 model audit left exactly one question open about the Chat default: it measured
+`gemini-3.8-flash` ~12% slower than `gemini-3.7-flash` (2958 vs 2640 ms, n=5, overlapping ranges)
+and said, correctly, that the comparison had to be redone properly before hiding 3.7. This is that
+comparison.
+
+Three things it does differently from a quick probe, each of which can flip the answer:
+
+  - **Interleaved, not batched.** A/B then B/A within every round, so a slow minute of the API
+    lands on both models instead of on whichever was measured second.
+  - **Time to first token, not total.** Chat streams into a bubble. What the reader feels is when
+    the first words appear; total time is mostly a function of how long an answer the model chose
+    to write, which is not a speed difference.
+  - **Real prompts.** Read straight out of the staged usage log, so the mix is the operator's own
+    (short factual questions, tool troubleshooting, opinion, one long paste) rather than whatever
+    a synthetic benchmark would have asked.
+
+    python3 scripts/benchmark-chat-latency.py [--rounds 3] [--models a,b] [--prompts N]
+
+Key from .env (GEMINI_API_KEY), same as the other model scripts. Output is written as a table plus
+a per-prompt breakdown; nothing is committed and no default is changed.
+"""
+import argparse, json, os, random, re, statistics, sys, time, urllib.request, urllib.error
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+STAGING = os.path.join(REPO, "build", "usage-review-staging")
+ENDPOINT = ("https://generativelanguage.googleapis.com/v1beta/models/"
+            "{model}:streamGenerateContent?alt=sse&key={key}")
+
+
+def api_key():
+    env = os.path.join(REPO, ".env")
+    if os.path.exists(env):
+        for line in open(env, encoding="utf-8"):
+            m = re.match(r"\s*(?:export\s+)?GEMINI_API_KEY\s*=\s*[\"']?([^\"'\s]+)", line)
+            if m:
+                return m.group(1)
+    return os.environ.get("GEMINI_API_KEY")
+
+
+def load_prompts(limit):
+    """Self-contained questions from the staged chat log — a follow-up like "und wo entsteht der?"
+    measures nothing without the thread it belonged to, so those are skipped."""
+    rows = []
+    for name in sorted(os.listdir(STAGING)):
+        if not name.startswith("interactions-"):
+            continue
+        for line in open(os.path.join(STAGING, name), encoding="utf-8"):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                r = json.loads(line)
+            except ValueError:
+                continue
+            if r.get("mode") != "geminiChat":
+                continue
+            text = re.sub(r"<[^>]+>", "", r.get("userInstruction") or "").strip()
+            if len(text) < 25:                      # "test", "double check", "where"
+                continue
+            if re.match(r"^(ja|nein|und|aber|okay|was denkst|double check)\b", text, re.I):
+                continue
+            rows.append(text)
+    # Spread across the length range rather than taking the first N: the long pastes are a real
+    # part of the mix and they are where a latency difference would actually be felt.
+    rows.sort(key=len)
+    if len(rows) <= limit:
+        return rows
+    step = len(rows) / limit
+    return [rows[int(i * step)] for i in range(limit)]
+
+
+def call(model, prompt, key, max_tokens, thinking, grounding):
+    """One streaming request, shaped like the app's own chat request rather than a bare probe.
+
+    Both matter and both were missing from the audit's probe. `GeminiAPIClient.swift:414` sends
+    `google_search` + `url_context` + `code_execution` on every chat turn, and
+    `PromptModel.geminiThinkingConfig` pins BOTH 3.7 and 3.8 to `thinkingLevel: low`. A search
+    round-trip lands before the first visible word, so a measurement without it is timing a code
+    path the operator never reaches.
+
+    Returns (ttft_ms, total_ms, out_chars) or (None, None, error)."""
+    payload = {
+        "contents": [{"role": "user", "parts": [{"text": prompt}]}],
+        "generationConfig": {"maxOutputTokens": max_tokens},
+    }
+    if thinking:
+        payload["generationConfig"]["thinkingConfig"] = {"thinkingLevel": thinking}
+    if grounding:
+        payload["tools"] = [{"google_search": {}}, {"url_context": {}}, {"code_execution": {}}]
+    body = json.dumps(payload).encode()
+    req = urllib.request.Request(ENDPOINT.format(model=model, key=key), data=body,
+                                 headers={"Content-Type": "application/json"})
+    start = time.perf_counter()
+    ttft = None
+    chars = 0
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            for raw in resp:
+                if not raw.startswith(b"data: "):
+                    continue
+                try:
+                    chunk = json.loads(raw[6:])
+                except ValueError:
+                    continue
+                for cand in chunk.get("candidates", []):
+                    for part in cand.get("content", {}).get("parts", []):
+                        text = part.get("text") or ""
+                        if text and ttft is None:
+                            ttft = (time.perf_counter() - start) * 1000
+                        chars += len(text)
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as exc:
+        return None, None, str(exc)
+    return ttft, (time.perf_counter() - start) * 1000, chars
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--models", default="gemini-3.7-flash,gemini-3.8-flash")
+    ap.add_argument("--rounds", type=int, default=3)
+    ap.add_argument("--prompts", type=int, default=12)
+    ap.add_argument("--max-tokens", type=int, default=1024,
+                    help="bounds cost; low enough to stay cheap, high enough for a real answer")
+    ap.add_argument("--thinking", default="low",
+                    help="thinkingLevel — 'low' is what the app pins 3.7 and 3.8 to")
+    ap.add_argument("--no-grounding", action="store_true",
+                    help="drop google_search/url_context/code_execution (NOT what the app does)")
+    args = ap.parse_args()
+
+    key = api_key()
+    if not key:
+        sys.exit("no GEMINI_API_KEY (put it in .env or the environment)")
+    models = [m.strip() for m in args.models.split(",")]
+    prompts = load_prompts(args.prompts)
+    print(f"{len(prompts)} prompts x {args.rounds} rounds x {len(models)} models = "
+          f"{len(prompts) * args.rounds * len(models)} calls · thinking={args.thinking or 'api default'} "
+          f"· grounding={'off' if args.no_grounding else 'on (as the app sends it)'}\n")
+
+    results = {m: {"ttft": [], "total": [], "chars": [], "errors": 0} for m in models}
+    per_prompt = []
+    for i, prompt in enumerate(prompts):
+        row = {"prompt": prompt, "len": len(prompt), "ttft": {m: [] for m in models}}
+        for r in range(args.rounds):
+            # Alternate the order every round: whichever model goes first pays for a cold
+            # connection and for whatever the API was doing that second.
+            order = models if (i + r) % 2 == 0 else list(reversed(models))
+            for model in order:
+                ttft, total, chars = call(model, prompt, key, args.max_tokens,
+                                          args.thinking, not args.no_grounding)
+                if ttft is None:
+                    results[model]["errors"] += 1
+                    continue
+                results[model]["ttft"].append(ttft)
+                results[model]["total"].append(total)
+                results[model]["chars"].append(chars)
+                row["ttft"][model].append(ttft)
+        per_prompt.append(row)
+        print(f"  [{i+1}/{len(prompts)}] {row['len']:5d}ch  " +
+              "  ".join(f"{m.split('-')[1]}={statistics.median(row['ttft'][m]):6.0f}ms"
+                        for m in models if row["ttft"][m]))
+
+    print("\n=== Time to first token (what you feel) ===")
+    print(f"{'model':22s} {'n':>4s} {'median':>9s} {'mean':>9s} {'p25':>9s} {'p75':>9s} {'errors':>7s}")
+    for m in models:
+        d = sorted(results[m]["ttft"])
+        if not d:
+            print(f"{m:22s}  no successful calls")
+            continue
+        print(f"{m:22s} {len(d):4d} {statistics.median(d):8.0f}m {statistics.mean(d):8.0f}m "
+              f"{d[len(d)//4]:8.0f}m {d[3*len(d)//4]:8.0f}m {results[m]['errors']:7d}")
+
+    print("\n=== Total time and answer length (context, not the verdict) ===")
+    for m in models:
+        if results[m]["total"]:
+            print(f"{m:22s} total median {statistics.median(results[m]['total']):6.0f} ms · "
+                  f"answer median {statistics.median(results[m]['chars']):5.0f} chars")
+
+    # Paired comparison: the same prompt, same round, both models — the only honest way to say
+    # "faster", because prompt difficulty varies far more than the models do.
+    if len(models) == 2:
+        a, b = models
+        deltas = [statistics.median(r["ttft"][a]) - statistics.median(r["ttft"][b])
+                  for r in per_prompt if r["ttft"][a] and r["ttft"][b]]
+        if deltas:
+            wins_b = sum(1 for d in deltas if d > 0)
+            print(f"\n=== Paired, per prompt (n={len(deltas)}) ===")
+            print(f"{b} faster on {wins_b}/{len(deltas)} prompts · "
+                  f"median delta {statistics.median(deltas):+.0f} ms "
+                  f"({'b faster' if statistics.median(deltas) > 0 else 'a faster'})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes the one question the 2026-09-03 model audit left open about the Chat default.

## What the old probe got wrong

Not the arithmetic — the request shape. The audit sent a bare `generateContent`. The app does not: it attaches `google_search` + `url_context` + `code_execution` to every chat turn (`GeminiAPIClient.swift:414`) and pins **both** models to `thinkingLevel: low` (`SettingsConfiguration.swift:587`/`:591`). A search round-trip lands before the first visible word, so a number measured without it times a code path no user reaches.

Two further changes, each able to flip the sign alone: interleaved A/B-then-B/A ordering, and **time to first token** instead of total time (total is mostly how long an answer the model chose to write — 3.8 writes ~18% more, which is verbosity wearing a speed difference's clothes).

## Result — 12 real prompts from the usage log × 3 rounds

| Model | Median TTFT | Mean | Paired wins |
|---|---|---|---|
| `gemini-3.7-flash` | 1603 ms | 2503 ms | 7 / 12 |
| `gemini-3.8-flash` | 1752 ms | 2457 ms | 5 / 12 |

Means within 2%, sign flips depending on the statistic, per-prompt winner near a coin flip. Per output character both are identical (2.40 vs 2.46 ms). **The 12% claim does not survive.**

Screenshot reading — ~10% of real chat turns (14 of 142 messages in the 2026-09-07 window carried an image and no text) and never measured before — is a tie as well.

## What changes

Nothing in the app. A tie does not justify hiding 3.7 via `chatReplacement`; the condition the audit set was "3.8 measures better", not "no worse". `ChatDefaults.selectedChatModel` is already `gemini38Flash`, so fresh installs get the current-generation model while an existing 3.7 selection stays until the user switches. That asymmetry is deliberate.

Adds `scripts/benchmark-chat-latency.py` so the comparison is repeatable rather than a one-off, records the run in `plans/model-audits/2026-09-08-chat-latency.md`, and amends the 2026-09-03 audit's open bullet so the next monthly run does not re-derive it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
