### PR TITLE
Escalate a build lane that fails every tick instead of failing silently

### DIFF
--- a/plans/agent-loops.md
+++ b/plans/agent-loops.md
@@ -378,3 +378,26 @@ python3 scripts/send-report-mail.py --subject "…" --body-file plans/…md \
     --verdict needs-decision --verdict-count 2 --verdict-detail "…" \
     --dry-run --html-out /tmp/preview.html
 ```
+
+### The other half: a mail that is never sent
+
+The contract above shapes mails that go out. It does nothing about the failure underneath it — a
+lane that stops mailing at all — and that is the one this repo actually shipped.
+
+On 2026-09-06 queue row #4 (gemini-3.8-flash) was promoted to `BUILD`, the build agent turned out
+to be logged out, and the run died leaving its worktree behind for the post-mortem, as designed.
+From 03:05 onward every hourly tick then hit `ERROR: worktree dir already exists … (clean up the
+previous run first)` — a precondition no retry can satisfy. `die` exits before any `report_out`,
+so the lane failed 40+ times across two days in complete silence and, from outside, was
+indistinguishable from an empty queue. The change sat unbuilt until a human happened to ask.
+
+The fix is deliberately not at the die-site. Escalating per error string would only cover the one
+failure already known; **`tick.sh` counts consecutive non-zero exits of `run-implementer.sh` and
+reports the streak, whatever produced it** — three failures before the first mail so a transient
+hour stays quiet, then once a day, measured in elapsed hours rather than tick count because this
+is a laptop and ticks are skipped whenever the lid is shut (`IMPLEMENTER_FAIL_ALERT_AFTER`, the
+same shape as the blocked-builds reporter above it). Any clean exit clears the streak, "nothing to
+do" included — that is the runner saying it got far enough to read the queue.
+
+The runner's own mails are untouched: a run that reaches `fail_run` still mails immediately. This
+is the net under every path that never gets that far.

--- a/scripts/implementer/tick.sh
+++ b/scripts/implementer/tick.sh
@@ -276,7 +276,93 @@ fi
 
 # The runner does its own preflight (lock, monthly budget, scope, clean tree) and exits 0 with
 # "nothing to do" when no BUILD/OPEN row exists, which is the common case. Let it decide.
+#
+# --- Why a non-zero exit is counted rather than only warned about ----------------------------
+# A single failure is normal and must not mail: a usage limit, a flaky network, an agent that
+# timed out once. The next tick retries and nobody needs to know. What is not normal is the SAME
+# failure every hour, and that is what this repo actually shipped on 2026-09-06: the build agent
+# was logged out, the run died leaving its worktree behind for the post-mortem, and from 03:05
+# onward every tick hit
+#
+#     ERROR: worktree dir already exists: …/implementer-q4-20260906 (clean up the previous run first)
+#
+# — a precondition that no retry can ever satisfy. `die` exits before any report_out, so the lane
+# failed 40+ times over two days in complete silence, and from outside it was indistinguishable
+# from a quiet queue. The row's change (gemini-3.8-flash) sat unbuilt the whole time.
+#
+# Escalating per die-site would have missed it: the fix has to hold for the next failure nobody
+# predicted, not for this string. So the tick counts consecutive non-zero exits and reports the
+# streak, whatever produced it. The runner's own mails are unaffected — a run that reaches
+# fail_run still mails immediately; this is the net under the paths that never get that far.
+#
+# Threshold and cadence mirror the blocked-builds reporter above, for the same reasons: three
+# failures before the first mail so a transient hour stays quiet, then once a day, measured
+# against elapsed hours rather than a tick count because this is a laptop and ticks are skipped
+# whenever the lid is shut.
+FAIL_STAMP="${TICK_LOG_DIR}/.run-failing-since"
+FAIL_COUNT_FILE="${FAIL_STAMP}.count"
+FAIL_REPORTED_FILE="${FAIL_STAMP}.reported"
+FAIL_THRESHOLD="${IMPLEMENTER_FAIL_ALERT_AFTER:-3}"
+
 log "step 2: starting the next build if one is due"
-bash "${SCRIPT_DIR}/run-implementer.sh" || warn "run-implementer.sh exited non-zero — see above"
+RUN_OUT="$(mktemp -t wstickrun)"
+if bash "${SCRIPT_DIR}/run-implementer.sh" 2>&1 | tee "$RUN_OUT"; then
+    # Any clean exit ends the streak — including "nothing to do", which is the runner telling us
+    # it got far enough to read the queue.
+    rm -f "$FAIL_STAMP" "$FAIL_COUNT_FILE" "$FAIL_REPORTED_FILE"
+else
+    warn "run-implementer.sh exited non-zero — see above"
+    [[ -f "$FAIL_STAMP" ]] || date +%s >"$FAIL_STAMP"
+    FAILS=$(( $(cat "$FAIL_COUNT_FILE" 2>/dev/null || echo 0) + 1 ))
+    echo "$FAILS" >"$FAIL_COUNT_FILE"
+    FAILING_HOURS=$(( ($(date +%s) - $(cat "$FAIL_STAMP")) / 3600 ))
+    LAST_REPORTED=$(cat "$FAIL_REPORTED_FILE" 2>/dev/null || echo 0)
+    if (( FAILS >= FAIL_THRESHOLD )) \
+        && { [[ ! -f "$FAIL_REPORTED_FILE" ]] || (( FAILING_HOURS >= LAST_REPORTED + 24 )); }; then
+        echo "$FAILING_HOURS" >"$FAIL_REPORTED_FILE"
+        # Three ticks inside one hour is possible (a catch-up burst after the lid opens), and
+        # "failing for 0h" reads like nothing is wrong. Count is the honest unit below an hour.
+        FAIL_SPAN="${FAILS} ticks in a row"
+        FAIL_HOURS_NOTE=""
+        if (( FAILING_HOURS >= 1 )); then
+            FAIL_SPAN="${FAILING_HOURS}h"
+            FAIL_HOURS_NOTE=" That is ${FAILING_HOURS}h with no build."
+        fi
+        FAIL_NOTE=$(mktemp -t wstickfail)
+        {
+            echo "The build lane has failed ${FAILS} ticks in a row.${FAIL_HOURS_NOTE}"
+            echo
+            echo "## What the last attempt printed"
+            echo
+            echo '```'
+            tail -25 "$RUN_OUT"
+            echo '```'
+            echo
+            echo "## Where to look"
+            echo
+            echo "Tick log:   ${TICK_LOG_DIR}/tick-$(date +%F).log"
+            echo "Run logs:   ${REPO_ROOT}/build/implementer/"
+            echo "Queue:      plans/implementer-queue.md"
+            echo
+            echo "A run that fails identically every hour is usually a leftover from an earlier"
+            echo "failure rather than a new fault — a kept post-mortem worktree is the common one:"
+            echo
+            echo "    git -C ${REPO_ROOT} worktree list"
+            echo "    git -C ${REPO_ROOT} worktree remove --force <path>"
+        } >"$FAIL_NOTE"
+        python3 "${REPO_ROOT}/scripts/send-report-mail.py" --to "${AUDIT_MAIL_TO:-mail@magnus-goedde.de}" \
+            --subject "WhisperShortcut implementer failing (${FAIL_SPAN})" \
+            --body-file "$FAIL_NOTE" \
+            --verdict needs-fix --verdict-detail "Every tick has tried to build and failed — \
+${FAIL_SPAN} now. Nothing automatic clears this: the tick will keep retrying and keep failing \
+the same way, and from the outside a failing lane looks exactly like an empty queue. Whatever the \
+row was proposing stays unbuilt until you look." \
+            --title "Implementer failing every tick" \
+            --meta "Consecutive failures=${FAILS}" --meta "Failing for=${FAIL_SPAN}" \
+            || osascript -e "display notification \"${FAILS} ticks in a row\" with title \"Implementer failing\"" >/dev/null 2>&1
+        rm -f "$FAIL_NOTE"
+    fi
+fi
+rm -f "$RUN_OUT"
 
 log "tick done"


### PR DESCRIPTION
## The failure this closes

On 2026-09-06 queue row #4 (gemini-3.8-flash) was promoted to `BUILD`. The build agent turned out to be logged out, the run died, and it left its worktree behind for the post-mortem — as designed. Every hourly tick from 03:05 onward then hit:

```
ERROR: worktree dir already exists: …/implementer-q4-20260906 (clean up the previous run first)
```

`die` exits before any `report_out`, so the lane failed **40+ times across two days in complete silence**. From outside it was indistinguishable from an empty queue, and the change sat unbuilt until someone happened to ask why the app was still on 3.7.

## The fix is not at the die-site

Escalating per error string would only cover the failure already known. `tick.sh` now counts **consecutive non-zero exits of `run-implementer.sh`** and reports the streak, whatever produced it.

- **Three failures before the first mail**, so a transient hour (usage limit, flaky network, one agent timeout) stays quiet and the next tick just retries.
- **Then once a day**, measured in **elapsed hours** rather than tick count — this is a laptop, ticks are skipped whenever the lid is shut, and a modulo test would step straight over the reporting hour across a closed night. Same shape as the blocked-builds reporter directly above it.
- **Any clean exit clears the streak**, "nothing to do" included — that is the runner saying it got far enough to read the queue.
- The mail quotes the **last 25 lines the run printed** and names the leftover-worktree cleanup, which is the common cause of an identical hourly failure.
- Threshold is `IMPLEMENTER_FAIL_ALERT_AFTER` (default 3).

The runner's own mails are untouched: a run that reaches `fail_run` still mails immediately. This is the net under every path that never gets that far.

It uses the verdict vocabulary from #60 — `needs-fix`, red banner, and a detail line that says plainly that nothing automatic clears it.

## Testing

End to end against a stub repo (stubbed runner, stubbed mailer, temp `HOME`, so nothing leaves the machine):

| after tick | mails | streak |
|---|---|---|
| 1 | 0 | 1 |
| 2 | 0 | 2 |
| 3 | **1** | 3 |
| 4 | 1 | 4 |
| clean run | 1 | state cleared |

Mail body and the rendered HTML (red `verdict-alarm` banner, dark palette) checked with `--dry-run --html-out`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
